### PR TITLE
Simplify CI installation examples

### DIFF
--- a/docs/src/installation/iai_callgrind.md
+++ b/docs/src/installation/iai_callgrind.md
@@ -71,5 +71,5 @@ Or, speed up the overall installation time with `binstall` using the
 
 ```yaml
 - uses: taiki-e/install-action@cargo-binstall
-- run: cargo binstall iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
+- run: cargo binstall -y iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
 ```

--- a/docs/src/installation/iai_callgrind.md
+++ b/docs/src/installation/iai_callgrind.md
@@ -63,13 +63,7 @@ version it's best to automate this step in the CI. A job step in the github
 actions CI could look like this
 
 ```yaml
-- name: Install iai-callgrind-runner
-  run: |
-    version=$(cargo metadata --format-version=1 |\
-      jq '.packages[] | select(.name == "iai-callgrind").version' |\
-      tr -d '"'
-    )
-    cargo install iai-callgrind-runner --version $version
+- run: cargo install iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
 ```
 
 Or, speed up the overall installation time with `binstall` using the
@@ -77,11 +71,5 @@ Or, speed up the overall installation time with `binstall` using the
 
 ```yaml
 - uses: taiki-e/install-action@cargo-binstall
-- name: Install iai-callgrind-runner
-  run: |
-    version=$(cargo metadata --format-version=1 |\
-      jq '.packages[] | select(.name == "iai-callgrind").version' |\
-      tr -d '"'
-    )
-    cargo binstall --no-confirm iai-callgrind-runner --version $version
+- run: cargo binstall iai-callgrind-runner@$(cargo pkgid iai-callgrind | cut -d@ -f2)
 ```


### PR DESCRIPTION
Thanks for the `iai-callgrind`! I was able to switch from [`iai`](https://github.com/bheisler/iai) in `bon` and remove the pin of an old version of `valgrind` (https://github.com/elastio/bon/pull/311).

What I liked about `iai` is that it didn't require a runner CLI and proc macro dependencies. Could be cool to have a lighter version with `iai-callgrind` using `iai` crate as an example, if that's possible