### PR TITLE
fix(part): The `old` details of a ProfilePart were stored on the wrong side

### DIFF
--- a/iai-callgrind-runner/src/runner/summary.rs
+++ b/iai-callgrind-runner/src/runner/summary.rs
@@ -714,7 +714,7 @@ impl ProfilePart {
     pub fn from_old(old: ParserOutput) -> Self {
         let metrics_summary = ToolMetricSummary::from_old_metrics(&old.metrics);
         Self {
-            details: EitherOrBoth::Left(old.into()),
+            details: EitherOrBoth::Right(old.into()),
             metrics_summary,
         }
     }


### PR DESCRIPTION
In edge cases it's possible that only old output is available for a part. In such a case the details like command, pid etc. were shown on the left side instead of the right side of the terminal output. The metrics are unaffected.