### PR TITLE
chore(cicd): Fix freebsd job. Increase disk space of image

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,6 @@
 # spell-checker:ignore taiki rustfmt binstall clippy taplo rustup nocapture
 # spell-checker:ignore nofile gnuabi armv gnueabi mipsel vmactions usesh proto
-# spell-checker:ignore tlsv connrefused copyback
+# spell-checker:ignore tlsv connrefused copyback toolsdirectory ghcup
 
 name: Build and Check
 
@@ -206,26 +206,48 @@ jobs:
     name: Build, check and test/FreeBSD
     needs: [format]
     runs-on: ubuntu-latest
-    env:
-      GUNGRAUN_VALGRIND_INCLUDE: "/usr/local/include"
-      GUNGRAUN_VALGRIND_PATH: "/usr/local/bin"
     steps:
       - uses: actions/checkout@v6
-      - name: Setup and run tests
-        id: test
-        uses: vmactions/freebsd-vm@v1
+        # This job should free around 20 - 30 GB disk space which is needed for
+        # the custom freebsd image which requires 30 GB disk space
+        # Source: https://www.geraldonit.com/mastering-disk-space-on-github-actions-runners-a-deep-dive-into-cleanup-strategies-for-x64-and-arm64-runners/
+      - name: Free disk space
+        run: |
+          echo Disk usage before
+          df -h /
+
+          # Remove unused tool caches
+          sudo rm -rf /usr/lib/jvm # Java JDK
+          sudo rm -rf /usr/local/.ghcup # Haskell compiler installer
+          sudo rm -rf /usr/local/lib/android # Android SDK/NDK
+          sudo rm -rf /usr/local/share/powershell # Powershell SDKs
+          sudo rm -rf /usr/share/dotnet # .NET runtimes and SDKs
+          sudo rm -rf /usr/share/swift # Swift runtime and SDKs
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" # Pre-cached tools (Node, Python, Go, Ruby, .NET SDKs, etc.)
+
+          echo Disk usage after
+          df -h /
+      - uses: cross-platform-actions/action@v0.32.0
+        env:
+          GUNGRAUN_VALGRIND_INCLUDE: "/usr/local/include"
+          GUNGRAUN_VALGRIND_PATH: "/usr/local/bin"
         with:
-          envs: "GUNGRAUN_VALGRIND_INCLUDE GUNGRAUN_VALGRIND_PATH"
-          usesh: true
-          sync: rsync
-          # copyback: `false` reduces run time by some minutes
-          copyback: false
-          prepare: |
-            pkg install -y valgrind curl llvm18 just npm-node22
-            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain stable --profile minimal -y
+          environment_variables: GUNGRAUN_VALGRIND_INCLUDE GUNGRAUN_VALGRIND_PATH
+          operating_system: freebsd
+          architecture: x86-64
+          version: "15.0"
+          shell: bash
+          memory: 10G
+          sync_files: runner-to-vm
+          # Our custom freebsd image with increased disk space (30G instead of
+          # 12G) and dependencies pre-installed
+          image_url: https://github.com/gungraun/freebsd-builder/releases/download/v0.1.1-custom/freebsd-15.0-x86-64.qcow2
           run: |
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain stable --profile minimal -y
             ./scripts/freebsd_print_info.sh
             ./scripts/freebsd_build_and_test.sh
+            echo Disk usage
+            df -h
       # Set `copyback` to `true` and enable for debugging.
       # - name: Upload target/gungraun
       #   if: ${{ always() }}

--- a/Justfile
+++ b/Justfile
@@ -201,12 +201,12 @@ build-docs:
 # A thorough build of all packages with `cargo hack` and the feature powerset (Uses: 'cargo-hack')
 [group('build')]
 build-hack: build-hack-runner
-    cargo hack --workspace --feature-powerset --exclude gungraun-runner build
+    cargo hack --workspace --feature-powerset --exclude gungraun-runner {{ if args != '' { args } else { '' } }} build
 
 # A thorough build of the gungraun-runner package (Uses: 'cargo-hack')
 [group('build')]
 build-hack-runner:
-    cargo hack --package gungraun-runner --feature-powerset --exclude-no-default-features --exclude-features api build
+    cargo hack --package gungraun-runner --feature-powerset --exclude-no-default-features --exclude-features api {{ if args != '' { args } else { '' } }} build
 
 # A build of the tests in all packages with `cargo hack` and the feature powerset (Uses: 'cargo-hack')
 [group('build')]

--- a/scripts/freebsd_build_and_test.sh
+++ b/scripts/freebsd_build_and_test.sh
@@ -20,12 +20,20 @@ cargo update
 echo Build with the feature powerset
 just build-hack
 
+# The freebsd github action vm tends to run out of space, so we run `cargo
+# clean` as often as possible
+cargo clean
+
 # This excludes the ui tests
 echo Run normal tests
 cargo test --workspace --exclude client-request-tests
 
+cargo clean
+
 echo Run client request tests
 cargo +stable test -p client-request-tests --test tests --release -- --nocapture
+
+cargo clean
 
 echo Run benchmark tests
 just full-bench-test-all

--- a/scripts/freebsd_print_info.sh
+++ b/scripts/freebsd_print_info.sh
@@ -5,10 +5,13 @@ set -e
 # shellcheck disable=SC1090
 . ~/.cargo/env
 
+uname -a
+echo "$SHELL"
+df -h
 pwd
 ls -lah
 whoami
-env
+env | sort
 freebsd-version
 
 valgrind --version


### PR DESCRIPTION
This pr fixes various issues with the freebsd job. Switch from vmactions/freebsd-vm to cross-platform-actions/action which allows using our own [custom image](https://github.com/gungraun/freebsd-builder) with higher disk size and most dependencies preinstalled.