### PR TITLE
feat: prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to
 - Documentation page for running Valgrind with a custom runner in the guide.
 - `--parallel` CLI option and environment variable to run benchmarks in
   parallel.
+- `gungraun::prelude` module for convenient importing of commonly used items:
+  `library_benchmark`, `library_benchmark_group`, `binary_benchmark`,
+  `binary_benchmark_group`, `main!`, `LibraryBenchmarkConfig`,
+  `BinaryBenchmarkConfig`, and `Command`.
 
 ### Changed
 

--- a/benchmark-tests/benches/guide/lib_bench_dhat.rs
+++ b/benchmark-tests/benches/guide/lib_bench_dhat.rs
@@ -4,9 +4,8 @@ mod my_lib {
 use std::hint::black_box;
 
 use benchmark_tests::setup_worst_case_array;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Dhat, EntryPoint, LibraryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, EntryPoint};
 
 #[library_benchmark]
 #[bench::worst_case_3(setup_worst_case_array(3))]

--- a/benchmark-tests/benches/guide/lib_bench_find_primes.rs
+++ b/benchmark-tests/benches/guide/lib_bench_find_primes.rs
@@ -1,9 +1,7 @@
 use std::hint::black_box;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Dhat, EntryPoint, LibraryBenchmarkConfig,
-    ValgrindTool,
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, EntryPoint, ValgrindTool};
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()

--- a/benchmark-tests/benches/guide/lib_bench_iter.rs
+++ b/benchmark-tests/benches/guide/lib_bench_iter.rs
@@ -7,7 +7,7 @@ mod my_lib {
 use std::hint::black_box;
 use std::path::PathBuf;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 fn read_dir() -> Vec<PathBuf> {
     std::fs::read_dir("benches/fixtures")

--- a/benchmark-tests/benches/guide/lib_bench_regression.rs
+++ b/benchmark-tests/benches/guide/lib_bench_regression.rs
@@ -1,9 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests as my_lib;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, EventKind, LibraryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EventKind};
 
 #[library_benchmark]
 #[bench::worst_case(vec![3, 2, 1])]

--- a/benchmark-tests/benches/guide/lib_bench_subprocess.rs
+++ b/benchmark-tests/benches/guide/lib_bench_subprocess.rs
@@ -3,9 +3,8 @@ use std::io;
 use std::path::PathBuf;
 use std::process::ExitStatus;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::OutputFormat;
 
 /// Suppose this is your library
 pub mod my_lib {

--- a/benchmark-tests/benches/guide/lib_bench_threads.rs
+++ b/benchmark-tests/benches/guide/lib_bench_threads.rs
@@ -1,9 +1,7 @@
 use std::hint::black_box;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, EntryPoint,
-    LibraryBenchmarkConfig, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EntryPoint, OutputFormat};
 
 /// Suppose this is your library
 pub mod my_lib {

--- a/benchmark-tests/benches/guide/lib_bench_tolerance.rs
+++ b/benchmark-tests/benches/guide/lib_bench_tolerance.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 use std::hint::black_box;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::OutputFormat;
 
 fn make_hashmap(num: usize) -> HashMap<String, usize> {
     (0..num).fold(HashMap::new(), |mut acc, e| {

--- a/benchmark-tests/benches/test_bin_bench/client_requests/test_bin_bench_client_requests.rs
+++ b/benchmark-tests/benches/test_bin_bench/client_requests/test_bin_bench_client_requests.rs
@@ -1,6 +1,5 @@
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Callgrind, Command,
-};
+use gungraun::prelude::*;
+use gungraun::Callgrind;
 
 #[binary_benchmark]
 #[bench::parse_output()]

--- a/benchmark-tests/benches/test_bin_bench/command_delay/test_bin_bench_command_delay.rs
+++ b/benchmark-tests/benches/test_bin_bench/command_delay/test_bin_bench_command_delay.rs
@@ -4,10 +4,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use std::{env, thread};
 
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Command, Delay,
-    DelayKind, Sandbox,
-};
+use gungraun::prelude::*;
+use gungraun::{Delay, DelayKind, Sandbox};
 
 const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 const FILE_EXISTS: &str = env!("CARGO_BIN_EXE_file-exists");

--- a/benchmark-tests/benches/test_bin_bench/compare_by_id/test_bin_bench_compare_by_id.rs
+++ b/benchmark-tests/benches/test_bin_bench/compare_by_id/test_bin_bench_compare_by_id.rs
@@ -1,7 +1,5 @@
-use gungraun::{
-    binary_benchmark, binary_benchmark_attribute, binary_benchmark_group, main, Bench,
-    BinaryBenchmark,
-};
+use gungraun::prelude::*;
+use gungraun::{binary_benchmark_attribute, Bench, BinaryBenchmark};
 
 const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 

--- a/benchmark-tests/benches/test_bin_bench/config/test_bin_bench_config.rs
+++ b/benchmark-tests/benches/test_bin_bench/config/test_bin_bench_config.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Dhat};
+use gungraun::prelude::*;
+use gungraun::Dhat;
 
 fn check_args() -> Vec<String> {
     let mut default_args = vec![

--- a/benchmark-tests/benches/test_bin_bench/filter/test_bin_bench_filter.rs
+++ b/benchmark-tests/benches/test_bin_bench/filter/test_bin_bench_filter.rs
@@ -1,4 +1,4 @@
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Command};
+use gungraun::prelude::*;
 
 const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 

--- a/benchmark-tests/benches/test_bin_bench/generics/test_bin_bench_generics.rs
+++ b/benchmark-tests/benches/test_bin_bench/generics/test_bin_bench_generics.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Command};
+use gungraun::prelude::*;
 
 pub const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 

--- a/benchmark-tests/benches/test_bin_bench/intro/test_bin_bench_intro.rs
+++ b/benchmark-tests/benches/test_bin_bench/intro/test_bin_bench_intro.rs
@@ -10,10 +10,8 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Pipe, Sandbox, Stdin,
-    Stdio,
-};
+use gungraun::prelude::*;
+use gungraun::{Pipe, Sandbox, Stdin, Stdio};
 
 // This constant stores the absolute path to our crate's binary `echo`. Our `echo` is really simple
 // and prints all arguments to stdout as the original `echo` would do. In case of multiple arguments

--- a/benchmark-tests/benches/test_bin_bench/iter/test_bin_bench_iter.rs
+++ b/benchmark-tests/benches/test_bin_bench/iter/test_bin_bench_iter.rs
@@ -1,7 +1,5 @@
-use gungraun::{
-    binary_benchmark, binary_benchmark_attribute, binary_benchmark_group, main, Bench,
-    BinaryBenchmark, BinaryBenchmarkConfig, OutputFormat, Sandbox,
-};
+use gungraun::prelude::*;
+use gungraun::{binary_benchmark_attribute, Bench, BinaryBenchmark, OutputFormat, Sandbox};
 
 const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 const FILE_EXISTS: &str = env!("CARGO_BIN_EXE_file-exists");

--- a/benchmark-tests/benches/test_bin_bench/list_arg/test_bin_bench_list_arg.rs
+++ b/benchmark-tests/benches/test_bin_bench/list_arg/test_bin_bench_list_arg.rs
@@ -1,4 +1,4 @@
-use gungraun::{binary_benchmark, binary_benchmark_group, main};
+use gungraun::prelude::*;
 
 #[binary_benchmark]
 fn echo_bench() -> gungraun::Command {

--- a/benchmark-tests/benches/test_bin_bench/low_level/test_bin_bench_low_level.rs
+++ b/benchmark-tests/benches/test_bin_bench/low_level/test_bin_bench_low_level.rs
@@ -1,9 +1,7 @@
 use std::path::PathBuf;
 
-use gungraun::{
-    binary_benchmark, binary_benchmark_attribute, binary_benchmark_group, main, Bench,
-    BinaryBenchmark, BinaryBenchmarkConfig, Command, OutputFormat, Sandbox, Stdio,
-};
+use gungraun::prelude::*;
+use gungraun::{binary_benchmark_attribute, Bench, BinaryBenchmark, OutputFormat, Sandbox, Stdio};
 
 const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 const ENV: &str = env!("CARGO_BIN_EXE_env");

--- a/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/test_bin_bench_main_and_group_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_bin_bench/main_and_group_setup_and_teardown/test_bin_bench_main_and_group_setup_and_teardown.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Write;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main};
+use gungraun::prelude::*;
 
 const GROUP_SETUP_FILE: &str = "/tmp/gungraun.group_setup.tmp";
 const READ_FILE: &str = env!("CARGO_BIN_EXE_read-file");

--- a/benchmark-tests/benches/test_bin_bench/nocapture/test_bin_bench_nocapture.rs
+++ b/benchmark-tests/benches/test_bin_bench/nocapture/test_bin_bench_nocapture.rs
@@ -1,7 +1,5 @@
-use gungraun::{
-    self, binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Dhat, Pipe,
-    Sandbox, Stdin, Stdio,
-};
+use gungraun::prelude::*;
+use gungraun::{self, Dhat, Pipe, Sandbox, Stdin, Stdio};
 
 const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 const PIPE: &str = env!("CARGO_BIN_EXE_pipe");

--- a/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel.rs
+++ b/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Command, Delay, DelayKind, Stdio};
+use gungraun::prelude::*;
+use gungraun::{Delay, DelayKind, Stdio};
 
 const SUFFIX: &str = "test-file";
 const PREFIX: &str = module_path!();

--- a/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_cleanup_on_error.rs
+++ b/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_cleanup_on_error.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Command, Delay, DelayKind, Stdio};
+use gungraun::prelude::*;
+use gungraun::{Delay, DelayKind, Stdio};
 
 #[binary_benchmark]
 fn exit_with_error() -> Command {

--- a/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_cleanup_on_panic.rs
+++ b/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_cleanup_on_panic.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Command, Delay, DelayKind, Stdio};
+use gungraun::prelude::*;
+use gungraun::{Delay, DelayKind, Stdio};
 
 #[binary_benchmark]
 fn exit_with_panic() -> Command {

--- a/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_consistency.rs
+++ b/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_consistency.rs
@@ -1,5 +1,5 @@
 use benchmark_tests::fibonacci;
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Command};
+use gungraun::prelude::*;
 
 fn setup_no_output() {
     fibonacci(5);

--- a/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_threads.rs
+++ b/benchmark-tests/benches/test_bin_bench/parallel/test_bin_bench_parallel_threads.rs
@@ -1,4 +1,4 @@
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Command};
+use gungraun::prelude::*;
 
 #[binary_benchmark]
 #[bench::one("1")]

--- a/benchmark-tests/benches/test_bin_bench/paths/test_bin_bench_paths.rs
+++ b/benchmark-tests/benches/test_bin_bench/paths/test_bin_bench_paths.rs
@@ -1,10 +1,8 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Callgrind, Command,
-    OutputFormat, Sandbox,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, OutputFormat, Sandbox};
 
 fn create_script(path: &str) {
     let script = r#"#!/usr/bin/env sh

--- a/benchmark-tests/benches/test_bin_bench/sandbox/test_bin_bench_sandbox.rs
+++ b/benchmark-tests/benches/test_bin_bench/sandbox/test_bin_bench_sandbox.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, OutputFormat, Sandbox,
-};
+use gungraun::prelude::*;
+use gungraun::{OutputFormat, Sandbox};
 
 const FILE_EXISTS: &str = env!("CARGO_BIN_EXE_file-exists");
 

--- a/benchmark-tests/benches/test_bin_bench/setup_and_teardown/test_bin_bench_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_bin_bench/setup_and_teardown/test_bin_bench_setup_and_teardown.rs
@@ -1,6 +1,5 @@
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, Bench, BinaryBenchmark, BinaryBenchmarkGroup,
-};
+use gungraun::prelude::*;
+use gungraun::{Bench, BinaryBenchmark, BinaryBenchmarkGroup};
 
 const ECHO: &str = env!("CARGO_BIN_EXE_echo");
 

--- a/benchmark-tests/benches/test_bin_bench/setup_child/test_bin_bench_setup_child.rs
+++ b/benchmark-tests/benches/test_bin_bench/setup_child/test_bin_bench_setup_child.rs
@@ -1,7 +1,8 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Pipe, Stdin};
+use gungraun::prelude::*;
+use gungraun::{Pipe, Stdin};
 
 const PIPE: &str = env!("CARGO_BIN_EXE_pipe");
 

--- a/benchmark-tests/benches/test_bin_bench/setup_child_exit_with_error/expected_stdout
+++ b/benchmark-tests/benches/test_bin_bench/setup_child_exit_with_error/expected_stdout
@@ -1,6 +1,6 @@
 test_bin_bench_setup_child_exit_with_error::group::benchmark :() -> target/release/pipe
 
-thread 'main' (<__PID__>) panicked at benchmark-tests/benches/test_bin_bench/setup_child_exit_with_error/test_bin_bench_setup_child_exit_with_error.rs:10:5:
+thread 'main' (<__PID__>) panicked at benchmark-tests/benches/test_bin_bench/setup_child_exit_with_error/test_bin_bench_setup_child_exit_with_error.rs:11:5:
 SETUP CHILD PROCESS
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 STDIN was:

--- a/benchmark-tests/benches/test_bin_bench/setup_child_exit_with_error/test_bin_bench_setup_child_exit_with_error.rs
+++ b/benchmark-tests/benches/test_bin_bench/setup_child_exit_with_error/test_bin_bench_setup_child_exit_with_error.rs
@@ -1,7 +1,8 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Pipe, Stdin};
+use gungraun::prelude::*;
+use gungraun::{Pipe, Stdin};
 
 const PIPE: &str = env!("CARGO_BIN_EXE_pipe");
 

--- a/benchmark-tests/benches/test_bin_bench/tools/test_bin_bench_tools.rs
+++ b/benchmark-tests/benches/test_bin_bench/tools/test_bin_bench_tools.rs
@@ -1,7 +1,5 @@
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, Bbv, BinaryBenchmarkConfig, Command, Dhat, Drd,
-    Helgrind, Massif, Memcheck, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Bbv, Dhat, Drd, Helgrind, Massif, Memcheck, OutputFormat};
 
 #[binary_benchmark]
 #[bench::trace_children()]

--- a/benchmark-tests/benches/test_lib_bench/all_args/test_lib_bench_all_args.rs
+++ b/benchmark-tests/benches/test_lib_bench/all_args/test_lib_bench_all_args.rs
@@ -1,9 +1,7 @@
 use std::hint::black_box;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, EntryPoint,
-    LibraryBenchmarkConfig, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EntryPoint, OutputFormat};
 
 #[cfg(any(target_vendor = "apple", target_os = "freebsd"))]
 pub fn get_data_collections_options_yes() -> LibraryBenchmarkConfig {

--- a/benchmark-tests/benches/test_lib_bench/cache_sim/test_lib_bench_cache_sim.rs
+++ b/benchmark-tests/benches/test_lib_bench/cache_sim/test_lib_bench_cache_sim.rs
@@ -1,10 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, setup_worst_case_array};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, EventKind, FlamegraphConfig,
-    LibraryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EventKind, FlamegraphConfig};
 
 #[library_benchmark(config = LibraryBenchmarkConfig::default()
     .tool(Callgrind::with_args(["--cache-sim=yes"]))

--- a/benchmark-tests/benches/test_lib_bench/cachegrind/test_lib_bench_cachegrind.rs
+++ b/benchmark-tests/benches/test_lib_bench/cachegrind/test_lib_bench_cachegrind.rs
@@ -1,9 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, setup_best_case_array};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Cachegrind, Callgrind, LibraryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::{Cachegrind, Callgrind};
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()

--- a/benchmark-tests/benches/test_lib_bench/compare/test_lib_bench_compare.rs
+++ b/benchmark-tests/benches/test_lib_bench/compare/test_lib_bench_compare.rs
@@ -1,7 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, setup_best_case_array, setup_worst_case_array};
-use gungraun::{library_benchmark, library_benchmark_group, main, Dhat, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
+use gungraun::Dhat;
 
 #[library_benchmark]
 #[bench::case_3(vec![1, 2, 3])]

--- a/benchmark-tests/benches/test_lib_bench/compiler_optimization/test_lib_bench_compiler_optimization.rs
+++ b/benchmark-tests/benches/test_lib_bench/compiler_optimization/test_lib_bench_compiler_optimization.rs
@@ -1,4 +1,4 @@
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 fn bench() -> Vec<u64> {

--- a/benchmark-tests/benches/test_lib_bench/default_tool/test_lib_bench_default_tool.rs
+++ b/benchmark-tests/benches/test_lib_bench/default_tool/test_lib_bench_default_tool.rs
@@ -1,9 +1,9 @@
 use std::hint::black_box;
 use std::process::ExitStatus;
 
+use gungraun::prelude::*;
 use gungraun::{
-    library_benchmark, library_benchmark_group, main, Bbv, Cachegrind, Callgrind, Dhat, Drd,
-    Helgrind, LibraryBenchmarkConfig, Massif, Memcheck, OutputFormat, ValgrindTool,
+    Bbv, Cachegrind, Callgrind, Dhat, Drd, Helgrind, Massif, Memcheck, OutputFormat, ValgrindTool,
 };
 
 #[library_benchmark]

--- a/benchmark-tests/benches/test_lib_bench/dhat/test_lib_bench_dhat.rs
+++ b/benchmark-tests/benches/test_lib_bench/dhat/test_lib_bench_dhat.rs
@@ -1,10 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, setup_best_case_array, setup_worst_case_array};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Dhat, DhatMetric, EntryPoint,
-    LibraryBenchmarkConfig, ValgrindTool,
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, DhatMetric, EntryPoint, ValgrindTool};
 
 #[inline(never)]
 fn custom_setup(start: i32) -> Vec<i32> {

--- a/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
+++ b/benchmark-tests/benches/test_lib_bench/entry_point/test_lib_bench_entry_point.rs
@@ -1,10 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::assert::Assert;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, EntryPoint, EventKind,
-    FlamegraphConfig, LibraryBenchmarkConfig, ValgrindTool,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EntryPoint, EventKind, FlamegraphConfig, ValgrindTool};
 use gungraun_runner::runner::callgrind::hashmap_parser::SourcePath;
 use gungraun_runner::runner::metrics::Metric;
 use gungraun_runner::runner::summary::{BenchmarkSummary, ToolMetricSummary};

--- a/benchmark-tests/benches/test_lib_bench/envs/test_lib_bench_cli_env_clear.rs
+++ b/benchmark-tests/benches/test_lib_bench/envs/test_lib_bench_cli_env_clear.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use gungraun::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 
 const TMP_ENV_CLEAR: &str = "/tmp/gungraun_test_lib_bench_envs.env-clear";
 

--- a/benchmark-tests/benches/test_lib_bench/file_parameter/test_lib_bench_file_parameter.rs
+++ b/benchmark-tests/benches/test_lib_bench/file_parameter/test_lib_bench_file_parameter.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 fn consume_line(path: &PathBuf) -> String {
     let mut file = File::open(path).expect("Opening the file for reading should succeed");

--- a/benchmark-tests/benches/test_lib_bench/filter/test_lib_bench_filter.rs
+++ b/benchmark-tests/benches/test_lib_bench/filter/test_lib_bench_filter.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 #[bench::forty_two(42)]

--- a/benchmark-tests/benches/test_lib_bench/flamegraph/test_lib_bench_flamegraph.rs
+++ b/benchmark-tests/benches/test_lib_bench/flamegraph/test_lib_bench_flamegraph.rs
@@ -1,10 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::setup_worst_case_array;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, FlamegraphConfig, FlamegraphKind,
-    LibraryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, FlamegraphConfig, FlamegraphKind};
 
 #[library_benchmark]
 #[bench::all_kinds(

--- a/benchmark-tests/benches/test_lib_bench/generics/test_lib_bench_generics.rs
+++ b/benchmark-tests/benches/test_lib_bench/generics/test_lib_bench_generics.rs
@@ -4,7 +4,7 @@ use std::hint::black_box;
 /// Generic bench arguments cause compilation failure
 ///
 /// After the fix the benchmark should now compile
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 #[derive(Debug)]
 struct A;

--- a/benchmark-tests/benches/test_lib_bench/groups_envs/test_lib_bench_groups_envs.rs
+++ b/benchmark-tests/benches/test_lib_bench/groups_envs/test_lib_bench_groups_envs.rs
@@ -3,7 +3,7 @@
 use std::hint::black_box;
 
 use benchmark_tests::print_env;
-use gungraun::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 
 pub const TEST_VAR_1: &str = "__GUNGRAUN_TEST_VAR_1";
 pub const TEST_VAR_2: &str = "__GUNGRAUN_TEST_VAR_2";

--- a/benchmark-tests/benches/test_lib_bench/intro/test_lib_bench_intro.rs
+++ b/benchmark-tests/benches/test_lib_bench/intro/test_lib_bench_intro.rs
@@ -7,10 +7,8 @@ use std::io::{BufRead, BufReader};
 
 // These two functions from the benchmark-tests library serve as functions we want to benchmark
 use benchmark_tests::{bubble_sort, fibonacci};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, Dhat, EntryPoint, EventKind,
-    LibraryBenchmarkConfig, Massif,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, Dhat, EntryPoint, EventKind, Massif};
 
 // This function is used to create the worst case array we want to sort with our implementation of
 // bubble sort

--- a/benchmark-tests/benches/test_lib_bench/iter/test_lib_bench_iter.rs
+++ b/benchmark-tests/benches/test_lib_bench/iter/test_lib_bench_iter.rs
@@ -1,10 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, fibonacci, setup_worst_case_array};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Dhat, DhatMetric, LibraryBenchmarkConfig,
-    OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, DhatMetric, OutputFormat};
 
 #[inline(never)]
 fn setup_with_alloc(num: i32) -> Vec<i32> {

--- a/benchmark-tests/benches/test_lib_bench/list_arg/test_lib_bench_list_arg.rs
+++ b/benchmark-tests/benches/test_lib_bench/list_arg/test_lib_bench_list_arg.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 fn minimal_bench() -> u64 {

--- a/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_lib_bench/main_and_group_setup_and_teardown/test_lib_bench_main_and_group_setup_and_teardown.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 const GROUP_SETUP_FILE: &str = "/tmp/gungraun.group_setup.tmp";
 

--- a/benchmark-tests/benches/test_lib_bench/nocapture/test_lib_bench_nocapture.rs
+++ b/benchmark-tests/benches/test_lib_bench/nocapture/test_lib_bench_nocapture.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 fn setup_to_stdout(value: u64) -> u64 {
     println!("setup: stdout: {value}");

--- a/benchmark-tests/benches/test_lib_bench/output_format/test_lib_bench_output_format.rs
+++ b/benchmark-tests/benches/test_lib_bench/output_format/test_lib_bench_output_format.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, setup_worst_case_array};
+use gungraun::prelude::*;
 use gungraun::{
-    library_benchmark, library_benchmark_group, main, Cachegrind, CachegrindMetric,
-    CachegrindMetrics, Callgrind, CallgrindMetrics, Dhat, DhatMetric, Drd, ErrorMetric, EventKind,
-    Helgrind, LibraryBenchmarkConfig, Memcheck, OutputFormat, ValgrindTool,
+    Cachegrind, CachegrindMetric, CachegrindMetrics, Callgrind, CallgrindMetrics, Dhat, DhatMetric,
+    Drd, ErrorMetric, EventKind, Helgrind, Memcheck, OutputFormat, ValgrindTool,
 };
 
 fn make_hashmap(num: usize) -> HashMap<String, usize> {

--- a/benchmark-tests/benches/test_lib_bench/output_format/test_lib_bench_output_format_threads.rs
+++ b/benchmark-tests/benches/test_lib_bench/output_format/test_lib_bench_output_format_threads.rs
@@ -1,9 +1,7 @@
 use std::hint::black_box;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, Dhat, EntryPoint,
-    LibraryBenchmarkConfig, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, Dhat, EntryPoint, OutputFormat};
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()

--- a/benchmark-tests/benches/test_lib_bench/parallel/test_lib_bench_parallel.rs
+++ b/benchmark-tests/benches/test_lib_bench/parallel/test_lib_bench_parallel.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::thread::sleep;
 use std::time::Duration;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use tempfile::Builder;
 
 const SUFFIX: &str = "test-file";

--- a/benchmark-tests/benches/test_lib_bench/parallel/test_lib_bench_parallel_cleanup_on_panic.rs
+++ b/benchmark-tests/benches/test_lib_bench/parallel/test_lib_bench_parallel_cleanup_on_panic.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::thread::sleep;
 use std::time::Duration;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use tempfile::Builder;
 
 const SUFFIX: &str = "test-file";

--- a/benchmark-tests/benches/test_lib_bench/parallel/test_lib_bench_parallel_consistency.rs
+++ b/benchmark-tests/benches/test_lib_bench/parallel/test_lib_bench_parallel_consistency.rs
@@ -1,7 +1,8 @@
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, setup_worst_case_array};
-use gungraun::{library_benchmark, library_benchmark_group, main, Dhat, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
+use gungraun::Dhat;
 
 #[inline(never)]
 fn setup_with_output(input: i32) -> Vec<i32> {

--- a/benchmark-tests/benches/test_lib_bench/parts/test_lib_bench_parts.rs
+++ b/benchmark-tests/benches/test_lib_bench/parts/test_lib_bench_parts.rs
@@ -2,10 +2,8 @@ use std::hint::black_box;
 use std::process::{Command, ExitStatus};
 
 use benchmark_tests::{find_primes, find_primes_multi_thread_with_instrumentation};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, EntryPoint,
-    LibraryBenchmarkConfig, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EntryPoint, OutputFormat};
 
 #[library_benchmark]
 #[bench::dump_every_bb(

--- a/benchmark-tests/benches/test_lib_bench/readme_example_fibonacci/test_lib_bench_readme_example_fibonacci.rs
+++ b/benchmark-tests/benches/test_lib_bench/readme_example_fibonacci/test_lib_bench_readme_example_fibonacci.rs
@@ -1,8 +1,7 @@
 use std::hint::black_box;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Callgrind, LibraryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::Callgrind;
 
 fn fibonacci(n: u64) -> u64 {
     match n {

--- a/benchmark-tests/benches/test_lib_bench/setup_and_teardown/test_lib_bench_setup_and_teardown.rs
+++ b/benchmark-tests/benches/test_lib_bench/setup_and_teardown/test_lib_bench_setup_and_teardown.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 fn setup_two_arguments(first: u64, second: u64) -> u64 {
     first + second

--- a/benchmark-tests/benches/test_lib_bench/threads/test_lib_bench_threads.rs
+++ b/benchmark-tests/benches/test_lib_bench/threads/test_lib_bench_threads.rs
@@ -2,10 +2,8 @@ use std::hint::black_box;
 use std::process::Command;
 
 use benchmark_tests::find_primes_multi_thread;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Bbv, Callgrind, Dhat, Drd,
-    LibraryBenchmarkConfig, Massif, Memcheck, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Bbv, Callgrind, Dhat, Drd, Massif, Memcheck, OutputFormat};
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()

--- a/benchmark-tests/benches/test_lib_bench/threads/test_lib_bench_threads_nested.rs
+++ b/benchmark-tests/benches/test_lib_bench/threads/test_lib_bench_threads_nested.rs
@@ -2,10 +2,8 @@ use std::hint::black_box;
 use std::process::Command;
 
 use benchmark_tests::thread_in_thread_with_instrumentation;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Bbv, Callgrind, Dhat, Drd, EntryPoint,
-    LibraryBenchmarkConfig, Massif, Memcheck, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Bbv, Callgrind, Dhat, Drd, EntryPoint, Massif, Memcheck, OutputFormat};
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()

--- a/benchmark-tests/benches/test_lib_bench/tools/test_lib_bench_tools.rs
+++ b/benchmark-tests/benches/test_lib_bench/tools/test_lib_bench_tools.rs
@@ -11,10 +11,8 @@ struct Right(Option<Rc<RefCell<Left>>>);
 use std::hint::black_box;
 
 use benchmark_tests::{bubble_sort, bubble_sort_allocate, setup_worst_case_array, subprocess};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Bbv, Callgrind, Dhat, Drd, EventKind,
-    Helgrind, LibraryBenchmarkConfig, Massif, Memcheck, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{Bbv, Callgrind, Dhat, Drd, EventKind, Helgrind, Massif, Memcheck, OutputFormat};
 
 #[library_benchmark]
 #[bench::empty(

--- a/benchmark-tests/benches/test_lib_bench/valgrind_runner/test_lib_bench_valgrind_runner.rs
+++ b/benchmark-tests/benches/test_lib_bench/valgrind_runner/test_lib_bench_valgrind_runner.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 fn simple() -> u64 {

--- a/benchmark-tests/benches/test_lib_bench/xtree/test_lib_bench_xtree.rs
+++ b/benchmark-tests/benches/test_lib_bench/xtree/test_lib_bench_xtree.rs
@@ -1,8 +1,6 @@
 use benchmark_tests::{bubble_sort, leak_memory, setup_worst_case_array, subprocess};
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Helgrind, LibraryBenchmarkConfig, Massif,
-    Memcheck, ValgrindTool,
-};
+use gungraun::prelude::*;
+use gungraun::{Helgrind, Massif, Memcheck, ValgrindTool};
 
 #[library_benchmark(setup = setup_worst_case_array)]
 #[bench::memcheck_xtree(

--- a/docs/src/benchmarks/binary_benchmarks/configuration/delay.md
+++ b/docs/src/benchmarks/binary_benchmarks/configuration/delay.md
@@ -15,9 +15,8 @@ use std::net::{SocketAddr, TcpListener};
 use std::time::Duration;
 use std::thread;
 
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, Delay, DelayKind
-};
+use gungraun::prelude::*;
+use gungraun::{Delay, DelayKind};
 
 const ADDRESS: &str = "127.0.0.1:31000";
 

--- a/docs/src/benchmarks/binary_benchmarks/configuration/exit_code.md
+++ b/docs/src/benchmarks/binary_benchmarks/configuration/exit_code.md
@@ -8,9 +8,8 @@ different from `0`, the expected exit code can be set in
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{
-     binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, ExitWith
-};
+use gungraun::prelude::*;
+use gungraun::ExitWith;
 
 #[binary_benchmark]
 // Here, we set the expected exit code of `my-foo` to 2

--- a/docs/src/benchmarks/binary_benchmarks/configuration/sandbox.md
+++ b/docs/src/benchmarks/binary_benchmarks/configuration/sandbox.md
@@ -36,9 +36,8 @@ without error.
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Sandbox
-};
+use gungraun::prelude::*;
+use gungraun::Sandbox;
 
 fn create_file(path: &str) {
     std::fs::write(path, "some content").unwrap();
@@ -77,9 +76,8 @@ to copy `fixtures` into the temporary directory with `Sandbox::fixtures`:
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Sandbox
-};
+use gungraun::prelude::*;
+use gungraun::Sandbox;
 
 #[binary_benchmark]
 #[bench::foo(
@@ -118,9 +116,9 @@ can copy it into a temporary directory `tmp` (which may or may not exist) in
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig, Sandbox
-};
+use gungraun::prelude::*;
+use gungraun::Sandbox;
+
 use std::path::PathBuf;
 
 fn copy_fixture(path: &str) {

--- a/docs/src/benchmarks/binary_benchmarks/differences.md
+++ b/docs/src/benchmarks/binary_benchmarks/differences.md
@@ -47,7 +47,7 @@ benchmark.
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{binary_benchmark, binary_benchmark_group, main};
+use gungraun::prelude::*;
 use std::path::PathBuf;
 
 #[binary_benchmark]
@@ -88,7 +88,7 @@ work differently.
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{binary_benchmark, binary_benchmark_group, main};
+use gungraun::prelude::*;
 
 fn create_file() {
     std::fs::write("foo.txt", "some content").unwrap();
@@ -122,7 +122,7 @@ library benchmarks:
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{binary_benchmark, binary_benchmark_group, main};
+use gungraun::prelude::*;
 
 fn create_file(path: &str) {
     std::fs::write(path, "some content").unwrap();

--- a/docs/src/benchmarks/binary_benchmarks/important.md
+++ b/docs/src/benchmarks/binary_benchmarks/important.md
@@ -22,7 +22,8 @@ with
 
 ```rust
 # extern crate gungraun;
-use gungraun::{BinaryBenchmarkConfig, Callgrind};
+use gungraun::prelude::*;
+use gungraun::Callgrind;
 
 BinaryBenchmarkConfig::default().tool(Callgrind::with_args(["--cache-sim=no"]));
 ```
@@ -32,10 +33,8 @@ To switch off cache simulation for all benchmarks in the same file:
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, BinaryBenchmarkConfig,
-    Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::Callgrind;
 
 #[binary_benchmark]
 fn bench_binary() -> gungraun::Command {

--- a/docs/src/benchmarks/binary_benchmarks/low_level.md
+++ b/docs/src/benchmarks/binary_benchmarks/low_level.md
@@ -10,10 +10,8 @@ The entry point of the low-level API is the `binary_benchmark_group`
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{
-     binary_benchmark, binary_benchmark_attribute, binary_benchmark_group, main,
-     BinaryBenchmark, Bench
-};
+use gungraun::prelude::*;
+use gungraun::{binary_benchmark_attribute, BinaryBenchmark, Bench};
 
 binary_benchmark_group!(
     name = my_group,
@@ -67,10 +65,8 @@ other way around is much more involved.
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{
-     binary_benchmark, binary_benchmark_attribute, binary_benchmark_group, main,
-     BinaryBenchmark, Bench
-};
+use gungraun::prelude::*;
+use gungraun::{binary_benchmark_attribute, BinaryBenchmark, Bench};
 
 #[binary_benchmark]
 #[bench::some_id("foo")]

--- a/docs/src/benchmarks/binary_benchmarks/quickstart.md
+++ b/docs/src/benchmarks/binary_benchmarks/quickstart.md
@@ -9,7 +9,7 @@ high-level API with the `#[binary_benchmark]` attribute:
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{binary_benchmark, binary_benchmark_group, main};
+use gungraun::prelude::*;
 
 #[binary_benchmark]
 #[bench::some_id("foo.txt")]
@@ -76,7 +76,8 @@ written with the low-level API:
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{BinaryBenchmark, Bench, binary_benchmark_group, main};
+use gungraun::prelude::*;
+use gungraun::{BinaryBenchmark, Bench};
 
 binary_benchmark_group!(
     name = my_group,

--- a/docs/src/benchmarks/binary_benchmarks/quickstart.md
+++ b/docs/src/benchmarks/binary_benchmarks/quickstart.md
@@ -29,10 +29,11 @@ main!(binary_benchmark_groups = my_group);
 # }
 ```
 
-If you want to try out this example with your crate's binary, put the above code
-into a file in `$WORKSPACE_ROOT/benches/binary_benchmark.rs`. Next, replace
-`my-foo` in `env!("CARGO_BIN_EXE_my-foo")` with the name of a binary of your
-crate.
+The `gungraun::prelude` contains the most important macro definitions and
+structs. If you want to try out this example with your crate's binary, put the
+above code into a file in `$WORKSPACE_ROOT/benches/binary_benchmark.rs`. Next,
+replace `my-foo` in `env!("CARGO_BIN_EXE_my-foo")` with the name of a binary of
+your crate.
 
 Note the `env!` macro is a [rust] builtin macro and `CARGO_BIN_EXE_<name>` is
 documented in [rust stdlib][cargo-env].

--- a/docs/src/benchmarks/binary_benchmarks/stdin_and_pipe.md
+++ b/docs/src/benchmarks/binary_benchmarks/stdin_and_pipe.md
@@ -19,7 +19,8 @@ or `Stderr` as `Stdin` for the `Command`.
 ```rust
 # extern crate gungraun;
 # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-use gungraun::{binary_benchmark, binary_benchmark_group, main, Stdin, Pipe};
+use gungraun::prelude::*;
+use gungraun::{Stdin, Pipe};
 
 fn setup_pipe() {
     println!(

--- a/docs/src/benchmarks/library_benchmarks/compare_by_id.md
+++ b/docs/src/benchmarks/library_benchmarks/compare_by_id.md
@@ -12,7 +12,7 @@ addition to the usual comparison with the previous run:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/docs/src/benchmarks/library_benchmarks/configuration.md
+++ b/docs/src/benchmarks/library_benchmarks/configuration.md
@@ -16,8 +16,7 @@ The different levels where a `LibraryBenchmarkConfig` can be specified.
 
 ```rust
 # extern crate gungraun;
-# use gungraun::{library_benchmark, library_benchmark_group};
-use gungraun::{main, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 
 # #[library_benchmark] fn bench() {}
 # library_benchmark_group!(name = my_group, benchmarks = bench);
@@ -33,8 +32,7 @@ main!(
 
 ```rust
 # extern crate gungraun;
-# use gungraun::library_benchmark;
-use gungraun::{main, LibraryBenchmarkConfig, library_benchmark_group};
+use gungraun::prelude::*;
 
 # #[library_benchmark] fn bench() {}
 library_benchmark_group!(
@@ -53,9 +51,7 @@ main!(library_benchmark_groups = my_group);
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{
-    main, LibraryBenchmarkConfig, library_benchmark_group, library_benchmark
-};
+use gungraun::prelude::*;
 
 #[library_benchmark(config = LibraryBenchmarkConfig::default())]
 fn bench() {
@@ -78,9 +74,7 @@ main!(library_benchmark_groups = my_group);
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{
-    main, LibraryBenchmarkConfig, library_benchmark_group, library_benchmark
-};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 #[bench::some_id(args = (1, 2), config = LibraryBenchmarkConfig::default())]

--- a/docs/src/benchmarks/library_benchmarks/configuration/output_format.md
+++ b/docs/src/benchmarks/library_benchmarks/configuration/output_format.md
@@ -35,8 +35,8 @@ same file in the `main!` macro:
 
 ```rust
 # extern crate gungraun;
-# use gungraun::{library_benchmark, library_benchmark_group};
-use gungraun::{main, LibraryBenchmarkConfig, CallgrindMetrics, Callgrind};
+use gungraun::prelude::*;
+use gungraun::{CallgrindMetrics, Callgrind};
 
 # #[library_benchmark] fn bench() {}
 # library_benchmark_group!(name = my_group, benchmarks = bench);
@@ -103,9 +103,8 @@ to tolerate a specific margin in the benchmark output:
 use std::collections::HashMap;
 use std::hint::black_box;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig, OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::{LibraryBenchmarkConfig, OutputFormat};
 
 fn make_hashmap(num: usize) -> HashMap<String, usize> {
     (0..num).fold(HashMap::new(), |mut acc, e| {

--- a/docs/src/benchmarks/library_benchmarks/custom_entry_point.md
+++ b/docs/src/benchmarks/library_benchmarks/custom_entry_point.md
@@ -28,7 +28,7 @@ simplified, but conveying the basic idea, here is a commented example:
 
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{main,library_benchmark_group, library_benchmark};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -62,10 +62,8 @@ works only reliably for functions which are not inlined by the compiler.
 
 ```rust
 # extern crate gungraun;
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    EntryPoint, Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::{EntryPoint, Callgrind};
 use std::hint::black_box;
 
 mod my_lib {

--- a/docs/src/benchmarks/library_benchmarks/generic.md
+++ b/docs/src/benchmarks/library_benchmarks/generic.md
@@ -13,7 +13,7 @@ it is convenient especially when you have to specify many paths, don't do this:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn count_lines_in_file_fast(_path: std::path::PathBuf) -> u64 { 1 } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -38,7 +38,7 @@ almost never what you intended. You should instead convert the argument to a
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn count_lines_in_file_fast(_path: std::path::PathBuf) -> u64 { 1 } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -72,7 +72,7 @@ is the same as for the `args` parameter:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn create_buffer(_: usize) -> Vec<u8> { vec![] } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -101,7 +101,7 @@ For functions with multiple const generics:
 # mod my_lib { pub fn create_matrix(_: usize, _: usize) -> Vec<Vec<u8>> {
 #     vec![] }
 # }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -133,7 +133,7 @@ parameters in the benchmark function signature:
 #       Vec::with_capacity(SIZE)
 #   }
 # }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/docs/src/benchmarks/library_benchmarks/important.md
+++ b/docs/src/benchmarks/library_benchmarks/important.md
@@ -25,7 +25,8 @@ cycles, you can easily switch cache simulation off for example with:
 
 ```rust
 # extern crate gungraun;
-use gungraun::{LibraryBenchmarkConfig, Callgrind};
+use gungraun::prelude::*;
+use gungraun::Callgrind;
 
 LibraryBenchmarkConfig::default().tool(Callgrind::with_args(["--cache-sim=no"]));
 ```
@@ -35,10 +36,8 @@ To switch off cache simulation for all benchmarks in the same file:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn fibonacci(a: u64) -> u64 { a } }
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::Callgrind;
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/docs/src/benchmarks/library_benchmarks/macros.md
+++ b/docs/src/benchmarks/library_benchmarks/macros.md
@@ -32,7 +32,7 @@ attributes.
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(value: Vec<i32>) -> Vec<i32> { value } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -59,10 +59,8 @@ The following parameters are accepted:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(value: Vec<i32>) -> Vec<i32> { value } }
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    OutputFormat
-};
+use gungraun::prelude::*;
+use gungraun::OutputFormat;
 use std::hint::black_box;
 
 #[library_benchmark(
@@ -111,7 +109,7 @@ arguments as a list of values. So, instead of
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(value: Vec<i32>) -> Vec<i32> { value } }
-use gungraun::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 // This function is used to create a worst case array we want to sort with our implementation of
@@ -151,7 +149,7 @@ array of arguments.
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(value: Vec<i32>) -> Vec<i32> { value } }
-use gungraun::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 pub fn worst_case(start: i32) -> Vec<i32> {
@@ -186,15 +184,15 @@ the lower amount of elements is repeated:
 #       Vec::with_capacity(SIZE)
 #   }
 # }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
 // This creates three benchmarks with args "foo" repeated and the three consts
-#[benches::small(args = ["foo"], consts = (10, 50, 100))]
+#[benches::small(args = ["foo"], consts = [10, 50, 100])]
 // This creates two benchmarks with args "foo" and "baz" and the consts `10000`
 // repeated
-#[benches::big(args = ["bar", "baz"], consts = (10000))]
+#[benches::big(args = ["bar", "baz"], consts = [10000])]
 fn bench_buffer<const SIZE: usize, T>(arg_t: T) -> Vec<Vec<u8>>
 where T: std::fmt::Display {
     black_box(my_lib::create_buffer::<SIZE, T>(black_box(arg_t)))

--- a/docs/src/benchmarks/library_benchmarks/multiple_benches.md
+++ b/docs/src/benchmarks/library_benchmarks/multiple_benches.md
@@ -10,7 +10,7 @@ Start with an example:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(value: Vec<i32>) -> Vec<i32> { value } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 use my_lib::bubble_sort;
 
@@ -43,7 +43,7 @@ function instead. The above `#[library_benchmark]` is roughly the same as
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(value: Vec<i32>) -> Vec<i32> { value } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 use my_lib::bubble_sort;
 
@@ -84,7 +84,7 @@ case. For example creating multiple benchmarks from a range:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn u64_to_string(input: u64) -> String { "1".to_owned() } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -108,7 +108,7 @@ separate benchmark.
 use std::hint::black_box;
 use std::path::PathBuf;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 fn read_dir() -> Vec<PathBuf> {
     std::fs::read_dir("benches/fixtures")
@@ -153,7 +153,7 @@ then
 ```rust,ignore
 # extern crate gungraun;
 # mod my_lib { pub fn string_to_u64(value: String) -> Result<u64, String> { Ok(1) } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -173,7 +173,7 @@ The above is roughly equivalent to the following but with the `args` parameter
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn string_to_u64(value: String) -> Result<u64, String> { Ok(1) } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -203,7 +203,7 @@ and your library has a function which converts from RGB to HSV color space:
 ```rust,ignore
 # extern crate gungraun;
 # mod my_lib { pub fn rgb_to_hsv(a: u8, b: u8, c:u8) -> (u16, u8, u8) { (a.into(), b, c) } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 fn decode_line(line: String) -> (u8, u8, u8) {
@@ -239,7 +239,7 @@ can specified the same way as the `args` parameter:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn create_buffer(_: usize) -> Vec<u8> { vec![] } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -261,7 +261,7 @@ elements the last `args` value repeats:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn process(_: i32, _: usize) -> i32 { 0 } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/docs/src/benchmarks/library_benchmarks/quickstart.md
+++ b/docs/src/benchmarks/library_benchmarks/quickstart.md
@@ -21,7 +21,7 @@ Then copy the following content into this file:
 
 ```rust
 # extern crate gungraun;
-use gungraun::{main, library_benchmark_group, library_benchmark};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 fn fibonacci(n: u64) -> u64 {

--- a/docs/src/benchmarks/library_benchmarks/quickstart.md
+++ b/docs/src/benchmarks/library_benchmarks/quickstart.md
@@ -2,8 +2,8 @@
 
 # Quickstart
 
-Create a file `$WORKSPACE_ROOT/benches/library_benchmark.rs` (or for best
-results use
+Create a file `$WORKSPACE_ROOT/benches/library_benchmark.rs` (for best results
+use
 [Use a Separate Workspace Member for Benchmarks](../../best_practices.md#use-a-separate-workspace-member-for-benchmarks))
 and add
 
@@ -49,7 +49,8 @@ main!(library_benchmark_groups = bench_fibonacci_group);
 # }
 ```
 
-Now, that your first library benchmark is set up, you can run it with
+The `gungraun::prelude` contains the most important macro definitions and
+structs. Now, that your first library benchmark is set up, you can run it with
 
 ```shell
 cargo bench

--- a/docs/src/benchmarks/library_benchmarks/setup_and_teardown.md
+++ b/docs/src/benchmarks/library_benchmarks/setup_and_teardown.md
@@ -24,7 +24,7 @@ indirection with great effect. The effect is best shown with an example:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn count_bytes_fast(_file: std::fs::File) -> u64 { 1 } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -75,7 +75,7 @@ parameter of the `#[library_benchmark]`:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn count_bytes_fast(_file: std::fs::File) -> u64 { 1 } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -121,7 +121,7 @@ argument:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn count_bytes_fast(_file: std::fs::File) -> u64 { 1 } }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 
 use std::hint::black_box;
 use std::path::PathBuf;

--- a/docs/src/benchmarks/library_benchmarks/structure.md
+++ b/docs/src/benchmarks/library_benchmarks/structure.md
@@ -4,7 +4,7 @@ We're reusing our example from the [Quickstart](./quickstart.md) section.
 
 ```rust
 # extern crate gungraun;
-use gungraun::{main, library_benchmark_group, library_benchmark};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 fn fibonacci(n: u64) -> u64 {
@@ -61,7 +61,7 @@ code being attributed to the benchmarked function.
 
 ```rust
 # extern crate gungraun;
-use gungraun::{main, library_benchmark_group, library_benchmark};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 fn some_setup_func(value: u64) -> u64 {

--- a/docs/src/benchmarks/library_benchmarks/threads_and_subprocesses.md
+++ b/docs/src/benchmarks/library_benchmarks/threads_and_subprocesses.md
@@ -17,10 +17,8 @@ and/or subprocesses you can switch on `OutputFormat::show_intermediate`:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn find_primes_multi_thread(_: u64) -> Vec<u64> { vec![]} }
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    OutputFormat
-};
+use gungraun::prelude::*;
+use gungraun::OutputFormat;
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -66,10 +64,8 @@ in a benchmark file `benches/lib_bench_threads.rs`
 
 ```rust
 # extern crate gungraun;
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    OutputFormat
-};
+use gungraun::prelude::*;
+use gungraun::OutputFormat;
 use std::hint::black_box;
 
 /// Suppose this is your library
@@ -182,10 +178,8 @@ easiest way and can be done like so:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn find_primes_multi_thread(_: usize) -> Vec<u64> { vec![] }}
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    EntryPoint, Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EntryPoint};
 use std::hint::black_box;
 
 #[library_benchmark(
@@ -305,10 +299,8 @@ off the `EntryPoint`:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn find_primes_multi_thread(_: usize) -> Vec<u64> { vec![] }}
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    EntryPoint, Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EntryPoint};
 use std::hint::black_box;
 
 #[library_benchmark(
@@ -465,10 +457,8 @@ use the following:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn find_primes_multi_thread(_: usize) -> Vec<u64> { vec![] }}
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    EntryPoint, Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EntryPoint};
 use std::hint::black_box;
 
 #[library_benchmark(
@@ -575,10 +565,8 @@ use std::io;
 use std::path::PathBuf;
 use std::process::ExitStatus;
 
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    OutputFormat,
-};
+use gungraun::prelude::*;
+use gungraun::OutputFormat;
 
 /// Suppose this is your library
 pub mod my_lib {
@@ -671,10 +659,8 @@ benchmark will just work:
 # use std::io;
 # use std::path::PathBuf;
 # use std::process::ExitStatus;
-# use gungraun::{
-#    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-#    OutputFormat, Callgrind
-# };
+# use gungraun::prelude::*;
+# use gungraun::{OutputFormat, Callgrind};
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()
         .tool(Callgrind::with_args(["--toggle-collect=cat::main"]))
@@ -765,10 +751,8 @@ without the toggle:
 # use std::io;
 # use std::path::PathBuf;
 # use std::process::ExitStatus;
-# use gungraun::{
-#    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-#    OutputFormat,
-# };
+# use gungraun::prelude::*;
+# use gungraun::OutputFormat;
 #[library_benchmark]
 #[bench::some(setup = create_file)]
 fn bench_subprocess(path: PathBuf) -> io::Result<ExitStatus> {

--- a/docs/src/best_practices.md
+++ b/docs/src/best_practices.md
@@ -69,14 +69,15 @@ Gungraun provides built-in mechanisms for this:
 ```rust
 # extern crate gungraun;
 # fn process_data(data: Vec<u64>) -> u64 { data.len() as u64 }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 fn expensive_setup(n: u64) -> Vec<u64> {
     (0..n).collect()
 }
 
-#[library_benchmark(setup = expensive_setup(1000))]
+#[library_benchmark]
+#[bench::with_setup(args = [100], setup = expensive_setup)]
 fn bench_processing(data: Vec<u64>) -> u64 {
     black_box(process_data(black_box(data)))
 }
@@ -97,10 +98,11 @@ input and output values:
 ```rust
 # extern crate gungraun;
 # fn expensive_computation(n: u64) -> u64 { n }
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]
+#[bench::low(5)]
 fn bench_example(n: u64) -> u64 {
     // Ensure `n` and `result` are used and not optimized away
     black_box(expensive_computation(black_box(n)))

--- a/docs/src/cachegrind.md
+++ b/docs/src/cachegrind.md
@@ -40,10 +40,8 @@ benchmark file run a specific benchmark function with Cachegrind:
 # extern crate gungraun;
 # pub mod my_lib { pub fn bubble_sort(input: Vec<i32>) -> Vec<i32> { input } }
 
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    client_requests, ValgrindTool
-};
+use gungraun::prelude::*;
+use gungraun::ValgrindTool;
 use std::hint::black_box;
 
 #[library_benchmark(
@@ -71,10 +69,8 @@ to start and stop the instrumentation:
 # extern crate gungraun;
 # pub mod my_lib { pub fn bubble_sort(input: Vec<i32>) -> Vec<i32> { input } }
 
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    ValgrindTool, client_requests, Cachegrind
-};
+use gungraun::prelude::*;
+use gungraun::{client_requests, ValgrindTool, Cachegrind};
 use std::hint::black_box;
 
 #[library_benchmark(

--- a/docs/src/cli_and_env/output/out_directory.md
+++ b/docs/src/cli_and_env/output/out_directory.md
@@ -38,7 +38,7 @@ package `my_package`
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{main, library_benchmark_group, library_benchmark};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/docs/src/cli_and_env/output/terminal_output.md
+++ b/docs/src/cli_and_env/output/terminal_output.md
@@ -31,7 +31,7 @@ Consider the following library benchmark in `benches/my_benchmark.rs`
 
 ```rust
 # extern crate gungraun;
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 fn print_to_stderr(value: u64) {

--- a/docs/src/cli_and_env/parallel.md
+++ b/docs/src/cli_and_env/parallel.md
@@ -54,7 +54,7 @@ For example, given the following structure:
 
 ```rust
 # extern crate gungraun;
-use gungraun::{library_benchmark, library_benchmark_group};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 fn bench_a() { /* ... */ }
@@ -108,7 +108,7 @@ isolation guarantees:
 
 ```rust
 # extern crate gungraun;
-use gungraun::{library_benchmark};
+use gungraun::prelude::*;
 // This is SAFE with --parallel - each benchmark gets its own process
 static mut COUNTER: usize = 0;
 
@@ -205,7 +205,7 @@ themselves cause conflicts:
 ```rust
 # extern crate gungraun;
 use std::path::PathBuf;
-use gungraun::{library_benchmark, library_benchmark_group};
+use gungraun::prelude::*;
 
 const DIR: &str = "/tmp/benchmark_temp";
 
@@ -281,7 +281,7 @@ You can get **highly variable, non-reproducible metrics**.
 ```rust
 # extern crate gungraun;
 # fn compute_intensively() {}
-use gungraun::{library_benchmark};
+use gungraun::prelude::*;
 use std::thread;
 // Benchmark spawns 8 threads internally
 #[library_benchmark]
@@ -371,7 +371,7 @@ The `max_parallel` parameter in `library_benchmark_group!` and
 
 ```rust
 # extern crate gungraun;
-# use gungraun::{library_benchmark, library_benchmark_group};
+# use gungraun::prelude::*;
 # #[library_benchmark] fn bench_a() {}
 # #[library_benchmark] fn bench_b() {}
 # #[library_benchmark] fn bench_c() {}
@@ -429,7 +429,7 @@ library_benchmark_group!(
 # #[library_benchmark] fn fast_bench_2() {}
 # #[library_benchmark] fn threaded_bench() {}
 # #[library_benchmark] fn io_bound_bench() {}
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::prelude::*;
 // These can run in parallel with each other
 library_benchmark_group!(
     name = fast_benches,
@@ -480,12 +480,11 @@ which [limits parallelism](#limiting-parallelism-per-group):
 
 ```rust
 # extern crate gungraun;
-# use gungraun::{library_benchmark};
 # #[library_benchmark] fn bench_a() {}
 # #[library_benchmark] fn bench_b() {}
 # #[library_benchmark] fn bench_c() {}
 # #[library_benchmark] fn problematic_bench() {}
-use gungraun::{library_benchmark_group};
+use gungraun::prelude::*;
 // These can run in parallel
 library_benchmark_group!(
     name = parallel_safe,

--- a/docs/src/client_requests.md
+++ b/docs/src/client_requests.md
@@ -85,7 +85,7 @@ expected:
 
 ```rust
 # extern crate gungraun;
-use gungraun::{main, library_benchmark_group, library_benchmark};
+use gungraun::prelude::*;
 use std::hint::black_box;
 
 pub mod my_lib {
@@ -128,10 +128,8 @@ the events when entering the benchmark function, not the moment
 
 ```rust
 # extern crate gungraun;
-use gungraun::{
-    main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig,
-    client_requests, EntryPoint, Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::{client_requests, Callgrind, EntryPoint};
 use std::hint::black_box;
 
 pub mod my_lib {

--- a/docs/src/dhat.md
+++ b/docs/src/dhat.md
@@ -52,9 +52,8 @@ necessary to set the entry point to the setup function (in this case, the
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
 
 use std::hint::black_box;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, Dhat, EntryPoint, LibraryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, EntryPoint};
 
 pub fn setup_worst_case_array(start: i32) -> Vec<i32> {
     if start.is_negative() {
@@ -138,10 +137,8 @@ worse than that.
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    Dhat, DhatMetric
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, DhatMetric};
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -194,10 +191,8 @@ to understand the basic idea.
 # extern crate gungraun;
 # mod benchmark_tests { pub fn find_primes_multi_thread (_: u64) -> Vec<u64> { vec![] } }
 use std::hint::black_box;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    ValgrindTool,
-};
+use gungraun::prelude::*;
+use gungraun::ValgrindTool;
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()
@@ -321,10 +316,8 @@ doesn't have to be specified) and additionally all threads which execute the
 # extern crate gungraun;
 # mod benchmark_tests { pub fn find_primes_multi_thread (_: u64) -> Vec<u64> { vec![] } }
 use std::hint::black_box;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    ValgrindTool, Dhat
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, ValgrindTool};
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()
@@ -367,10 +360,8 @@ specifying a frame with `Dhat::frames`:
 # extern crate gungraun;
 # mod benchmark_tests { pub fn find_primes_multi_thread (_: u64) -> Vec<u64> { vec![] } }
 use std::hint::black_box;
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    ValgrindTool, Dhat, EntryPoint
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, EntryPoint, ValgrindTool};
 
 #[library_benchmark(
     config = LibraryBenchmarkConfig::default()

--- a/docs/src/flamegraphs.md
+++ b/docs/src/flamegraphs.md
@@ -11,10 +11,8 @@ benchmark:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    FlamegraphConfig, Callgrind
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, FlamegraphConfig};
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/docs/src/regressions.md
+++ b/docs/src/regressions.md
@@ -137,10 +137,8 @@ soft limit of `+5%` for the `Ir` event kind for all benchmarks of this file:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    Callgrind, EventKind
-};
+use gungraun::prelude::*;
+use gungraun::{Callgrind, EventKind};
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -38,10 +38,8 @@ need for `--tools=dhat`:
 ```rust
 # extern crate gungraun;
 # mod my_lib { pub fn bubble_sort(_: Vec<i32>) -> Vec<i32> { vec![] } }
-use gungraun::{
-    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
-    ValgrindTool, Dhat
-};
+use gungraun::prelude::*;
+use gungraun::{Dhat, ValgrindTool};
 use std::hint::black_box;
 
 #[library_benchmark]

--- a/gungraun-macros/src/lib.rs
+++ b/gungraun-macros/src/lib.rs
@@ -495,6 +495,7 @@ pub fn library_benchmark(args: TokenStream, input: TokenStream) -> TokenStream {
 /// # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
 /// # use gungraun_macros::binary_benchmark;
 /// # pub mod gungraun {
+/// # pub mod prelude {}
 /// # use std::path::PathBuf;
 /// # #[derive(Clone)]
 /// # pub struct Command {}
@@ -538,7 +539,9 @@ pub fn library_benchmark(args: TokenStream, input: TokenStream) -> TokenStream {
 /// #    { fn from(_value: &mut BinaryBenchmarkConfig) -> Self { InternalBinaryBenchmarkConfig {}} }
 /// # }
 /// # }
-/// use gungraun::{BinaryBenchmarkConfig, Sandbox};
+/// # use gungraun::BinaryBenchmarkConfig;
+/// use gungraun::prelude::*;
+/// use gungraun::Sandbox;
 /// use std::path::PathBuf;
 ///
 /// // In binary benchmarks there's no need to return a value from the setup function

--- a/gungraun-runner/src/api.rs
+++ b/gungraun-runner/src/api.rs
@@ -871,7 +871,8 @@ pub enum EventKind {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use gungraun::{main, BinaryBenchmarkConfig, ExitWith};
+/// use gungraun::prelude::*;
+/// use gungraun::ExitWith;
 ///
 /// # fn main() {
 /// main!(

--- a/gungraun/src/lib.rs
+++ b/gungraun/src/lib.rs
@@ -401,6 +401,16 @@
 #![doc(test(attr(warn(unused))))]
 #![doc(test(attr(allow(unused_extern_crates))))]
 
+/// Import the basic macros and configuration structs with `use gungraun::prelude::*`
+#[cfg(feature = "default")]
+pub mod prelude {
+    #[doc(no_inline)]
+    pub use crate::{
+        binary_benchmark, binary_benchmark_group, library_benchmark, library_benchmark_group, main,
+        BinaryBenchmarkConfig, Command, LibraryBenchmarkConfig,
+    };
+}
+
 #[cfg(feature = "default")]
 #[doc(hidden)]
 pub mod __internal;

--- a/gungraun/src/lib.rs
+++ b/gungraun/src/lib.rs
@@ -30,8 +30,8 @@
 //! - __Regression__: Gungraun reports the difference between benchmark runs to make it easy to spot
 //!   detailed performance regressions and improvements.
 //! - __CPU and Cache Profiling__: Gungraun generates a Callgrind profile of your code while
-//!   benchmarking, so you can use Callgrind-compatible tools like [callgrind_annotate][cl-annotate]
-//!   or the visualizer [kcachegrind] to analyze the results in detail.
+//!   benchmarking, so you can use Callgrind-compatible tools like [`callgrind_annotate`] or the
+//!   visualizer [kcachegrind] to analyze the results in detail.
 //! - __Memory Profiling__: You can run other Valgrind tools like [DHAT: a dynamic heap analysis
 //!   tool][DHAT] and [Massif: a heap profiler][massif] with Gungraun. Their profiles are stored
 //!   next to the callgrind profiles and are ready to be examined with analyzing tools like
@@ -49,8 +49,7 @@
 //!
 //! ### Library Benchmarks
 //!
-//! Use this scheme of the [`main`] macro if you want to benchmark functions of your
-//! crate's library.
+//! Use the [`main!`] macro to benchmark functions of your crate's library.
 //!
 //! #### Important default behavior
 //!
@@ -87,7 +86,7 @@
 //!     }
 //! }
 //!
-//! // The #[library_benchmark] attribute let's you define a benchmark function which you
+//! // The #[library_benchmark] attribute lets you define a benchmark function which you
 //! // can later use in the `library_benchmark_groups!` macro.
 //! #[library_benchmark]
 //! fn bench_bubble_sort_empty() -> Vec<i32> {
@@ -167,15 +166,16 @@
 //! # }
 //! ```
 //!
-//! Note that it is important to annotate the benchmark functions with
-//! [`#[library_benchmark]`](crate::library_benchmark).
+//! The [`gungraun::prelude`](crate::prelude) contains the most important macro definitions and
+//! structs. Note that it is important to annotate the benchmark functions with
+//! [`#[library_benchmark]`].
 //!
 //! ### Configuration (#library-benchmarks)
 //!
 //! It's possible to configure some of the behavior of `gungraun`. See the docs of
-//! [`crate::LibraryBenchmarkConfig`] for more details. Configure library benchmarks at
-//! top-level with the [`crate::main`] macro, at group level within the
-//! [`crate::library_benchmark_group`], at [`crate::library_benchmark`] level
+//! [`LibraryBenchmarkConfig`] for more details. Configure library benchmarks at
+//! top-level with the [`main!`] macro, at group level within the
+//! [`library_benchmark_group!`], at [`#[library_benchmark]`] level
 //!
 //! and at `bench` level:
 //!
@@ -195,25 +195,25 @@
 //! configuration values like `envs` are additive and don't overwrite configuration values of higher
 //! levels.
 //!
-//! See also the docs of [`crate::library_benchmark_group`]. The [online guide][Guide] includes more
+//! See also the docs of [`library_benchmark_group!`]. The [online guide][Guide] includes more
 //! explanations, common recipes and examples.
 //!
 //! ### Binary Benchmarks
 //!
-//! Use this scheme of the [`main`] macro to benchmark one or more binaries of your crate (or any
+//! Use this scheme of the [`main!`] macro to benchmark one or more binaries of your crate (or any
 //! other executable). The documentation for setting up binary benchmarks with the
-//! `binary_benchmark_group` macro can be found in the docs of [`crate::binary_benchmark_group`].
+//! `binary_benchmark_group` macro can be found in the docs of [`binary_benchmark_group!`].
 //!
 //! #### Important default behavior
 //!
 //! By default, all binary benchmarks run with the environment variables cleared. See also
-//! [`crate::BinaryBenchmarkConfig::env_clear`] for how to change this behavior.
+//! [`BinaryBenchmarkConfig::env_clear`] for how to change this behavior.
 //!
 //! #### Quickstart (#binary-benchmarks)
 //!
 //! There are two apis to set up binary benchmarks, but we only describe the high-level api using
-//! the [`#[binary_benchmark]`](`crate::binary_benchmark`) attribute here. See the docs of
-//! [`binary_benchmark_group`] for more details about the low level api. The `#[binary_benchmark]`
+//! the [`#[binary_benchmark]`] attribute here. See the docs of
+//! [`binary_benchmark_group!`] for more details about the low level api. The `#[binary_benchmark]`
 //! attribute works almost the same as the `#[library_benchmark]` attribute. You will find the same
 //! parameters `setup`, `teardown`, `config`, `consts`, etc. in `#[binary_benchmark]` as in
 //! `#[library_benchmark]` and the inner attributes `#[bench]`, `#[benches]`. But, there are also
@@ -288,7 +288,7 @@
 //! As opposed to library benchmarks the function annotated with the `binary_benchmark` attribute
 //! always returns a `gungraun::Command`. More specifically, this function is not a benchmark
 //! function, since we don't benchmark functions anymore but [`Command`]s instead which are the
-//! return value of the [`#[binary_benchmark]`](crate::binary_benchmark) function.
+//! return value of the [`#[binary_benchmark]`] function.
 //!
 //! This change has far-reaching consequences but also simplifies things. Since the function itself
 //! is not benchmarked you can put any code into this function, and it does not influence the
@@ -300,7 +300,7 @@
 //!
 //! In library benchmarks the `setup` parameter only takes a path to a function, more specifically
 //! the function pointer. In binary benchmarks however, the `setup` (and `teardown`) parameters of
-//! the [`#[binary_benchmark]`](crate::binary_benchmark), `#[bench]` and `#[benches]` attribute
+//! the [`#[binary_benchmark]`], `#[bench]` and `#[benches]` attribute
 //! take expressions which includes function calls for example `setup = my_setup()`. Only in the
 //! special case that the expression is a function pointer, we pass the `args` of the `#[bench]` and
 //! `#[benches]` attributes into the `setup`, `teardown` __and__ the function itself. Also, these
@@ -319,8 +319,8 @@
 //! benchmarks, binary benchmarks can be also configured at a lower and last level in [`Command`]
 //! directly.
 //!
-//! For further details see the section about binary benchmarks of the [`crate::main`] docs the docs
-//! of [`crate::binary_benchmark_group`] and [`Command`]. The [guide][Guide] of this crate includes
+//! For further details see the section about binary benchmarks of the [`main!`] docs the docs
+//! of [`binary_benchmark_group!`] and [`Command`]. The [guide][Guide] of this crate includes
 //! a more thorough documentation with additional examples.
 //!
 //! ## Valgrind Tools
@@ -385,25 +385,117 @@
 //!
 //! [Cachegrind]: https://valgrind.org/docs/manual/cg-manual.html
 //! [Callgrind]: https://valgrind.org/docs/manual/cl-manual.html
-//! [cl-annotate]:
-//!   https://valgrind.org/docs/manual/cl-manual.html#cl-manual.callgrind_annotate-options
-//! [client-req]: https://valgrind.org/docs/manual/manual-core-adv.html#manual-core-adv.clientreq
 //! [DHAT]: https://valgrind.org/docs/manual/dh-manual.html
 //! [DRD]: https://valgrind.org/docs/manual/drd-manual.html
 //! [Guide]: https://gungraun.github.io/gungraun/latest/html/intro.html
 //! [Helgrind]: https://valgrind.org/docs/manual/hg-manual.html
-//! [kcachegrind]: https://kcachegrind.github.io/html/Home.html
-//! [massif]: https://valgrind.org/docs/manual/ms-manual.html
 //! [Memcheck]: https://valgrind.org/docs/manual/mc-manual.html
 //! [Valgrind User Manual]: https://valgrind.org/docs/manual/manual.html
+//! [`callgrind_annotate`]:
+//!   <https://valgrind.org/docs/manual/cl-manual.html#cl-manual.callgrind_annotate-options>
+//! [client-req]: https://valgrind.org/docs/manual/manual-core-adv.html#manual-core-adv.clientreq
+//! [kcachegrind]: https://kcachegrind.github.io/html/Home.html
+//! [massif]: https://valgrind.org/docs/manual/ms-manual.html
+//!
+//! [`#[binary_benchmark]`]: `crate::binary_benchmark`
+//! [`#[library_benchmark]`]: `crate::library_benchmark`
+//! [`BinaryBenchmarkConfig`]: `crate::BinaryBenchmarkConfig`
+//! [`BinaryBenchmarkConfig::env_clear`]: `crate::BinaryBenchmarkConfig::env_clear`
+//! [`BinaryBenchmarkConfig::tool`]: `crate::BinaryBenchmarkConfig::tool`
+//! [`Callgrind::flamegraph`]: `crate::Callgrind::flamegraph`
+//! [`Command`]: `crate::Command`
+//! [`FlamegraphConfig`]: `crate::FlamegraphConfig`
+//! [`LibraryBenchmarkConfig`]: `crate::LibraryBenchmarkConfig`
+//! [`LibraryBenchmarkConfig::tool`]: `crate::LibraryBenchmarkConfig::tool`
+//! [`binary_benchmark_group!`]: `crate::binary_benchmark_group`
+//! [`client_requests`]: `crate::client_requests`
+//! [`library_benchmark_group!`]: `crate::library_benchmark_group`
+//! [`main!`]: `crate::main`
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(test(attr(warn(unused))))]
 #![doc(test(attr(allow(unused_extern_crates))))]
 
-/// Import the basic macros and configuration structs with `use gungraun::prelude::*`
+/// Import the basic macros and configuration structs for benchmarking
+///
+/// The prelude is kept small and is focused on the most commonly used items for setting up
+/// benchmarks with Gungraun conveniently. A typical import would be:
+///
+/// ```
+/// use gungraun::prelude::*;
+/// ```
+///
+/// # Exported Items
+///
+/// ## Macros
+///
+/// - [`library_benchmark`]: Annotate a function as a library benchmark
+/// - [`library_benchmark_group`]: Define a group of library benchmarks
+/// - [`binary_benchmark`]: Annotate a function as a binary benchmark
+/// - [`binary_benchmark_group`]: Define a group of binary benchmarks
+/// - [`main!`]: Entry point macro that runs all benchmarks
+///
+/// ## Structs
+///
+/// - [`LibraryBenchmarkConfig`]: Configuration for library benchmarks
+/// - [`BinaryBenchmarkConfig`]: Configuration for binary benchmarks
+/// - [`Command`]: Build commands for binary benchmarks
+///
+/// # Library Benchmark Example
+///
+/// ```rust
+/// use std::hint::black_box;
+///
+/// use gungraun::prelude::*;
+///
+/// fn my_function(n: u64) -> u64 {
+///     n + 1
+/// }
+///
+/// #[library_benchmark]
+/// fn bench_my_function() -> u64 {
+///     black_box(my_function(black_box(42)))
+/// }
+///
+/// library_benchmark_group!(name = my_group, benchmarks = bench_my_function);
+/// # fn main() {
+/// main!(library_benchmark_groups = my_group);
+/// # }
+/// ```
+///
+/// # Binary Benchmark Example
+///
+/// ```rust
+/// use gungraun::prelude::*;
+///
+/// #[binary_benchmark]
+/// fn bench_my_binary() -> Command {
+///     Command::new("my-binary").arg("--option").build()
+/// }
+///
+/// binary_benchmark_group!(name = my_group, benchmarks = bench_my_binary);
+/// # fn main() {
+/// main!(binary_benchmark_groups = my_group);
+/// # }
+/// ```
+///
+/// # See Also
+///
+/// See the [module-level documentation](crate) or the [guide] for comprehensive guides and examples
+/// for both library and binary benchmarks.
+///
+/// [`BinaryBenchmarkConfig`]: crate::BinaryBenchmarkConfig
+/// [`Command`]: crate::Command
+/// [guide]: https://gungraun.github.io/gungraun/latest/html/intro.html
+/// [`LibraryBenchmarkConfig`]: crate::LibraryBenchmarkConfig
+/// [`binary_benchmark`]: crate::binary_benchmark
+/// [`binary_benchmark_group`]: crate::binary_benchmark_group
+/// [`library_benchmark`]: crate::library_benchmark
+/// [`library_benchmark_group`]: crate::library_benchmark_group
+/// [`main!`]: crate::main
 #[cfg(feature = "default")]
 pub mod prelude {
+    // Shows actual source location instead of prelude, making items easier to find for the user
     #[doc(no_inline)]
     pub use crate::{
         binary_benchmark, binary_benchmark_group, library_benchmark, library_benchmark_group, main,

--- a/gungraun/src/lib.rs
+++ b/gungraun/src/lib.rs
@@ -62,7 +62,7 @@
 //! ```rust
 //! use std::hint::black_box;
 //!
-//! use gungraun::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
+//! use gungraun::prelude::*;
 //!
 //! // Our function we want to test. Just assume this is a public function in your
 //! // library.
@@ -180,7 +180,7 @@
 //! and at `bench` level:
 //!
 //! ```rust
-//! # use gungraun::{LibraryBenchmarkConfig, library_benchmark};
+//! # use gungraun::prelude::*;
 //! #[library_benchmark]
 //! #[bench::some_id(args = (1, 2), config = LibraryBenchmarkConfig::default())]
 //! // ...
@@ -226,7 +226,7 @@
 //! use std::ffi::OsString;
 //! use std::path::PathBuf;
 //!
-//! use gungraun::{binary_benchmark, binary_benchmark_group, main};
+//! use gungraun::prelude::*;
 //!
 //! // In binary benchmarks there's no need to return a value from the setup function
 //! fn my_setup() {
@@ -334,8 +334,8 @@
 //! [`BinaryBenchmarkConfig::tool`]. For example to run `DHAT` for all library benchmarks:
 //!
 //! ```rust
-//! # use gungraun::{library_benchmark, library_benchmark_group};
-//! use gungraun::{main, Dhat, LibraryBenchmarkConfig};
+//! use gungraun::prelude::*;
+//! use gungraun::{main, Dhat};
 //! # #[library_benchmark]
 //! # fn some_func() {}
 //! # library_benchmark_group!(name = some_group, benchmarks = some_func);
@@ -351,8 +351,8 @@
 //! can change the default tool wherever a configuration can be specified. Here in `main!`:
 //!
 //! ```rust
-//! # use gungraun::{library_benchmark, library_benchmark_group};
-//! use gungraun::{main, LibraryBenchmarkConfig, ValgrindTool};
+//! use gungraun::prelude::*;
+//! use gungraun::{main, ValgrindTool};
 //! # #[library_benchmark]
 //! # fn some_func() {}
 //! # library_benchmark_group!(name = some_group, benchmarks = some_func);

--- a/gungraun/src/macros.rs
+++ b/gungraun/src/macros.rs
@@ -8,7 +8,8 @@
 ///
 /// ```rust
 /// # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-/// use gungraun::{binary_benchmark, binary_benchmark_attribute, binary_benchmark_group};
+/// use gungraun::binary_benchmark_attribute;
+/// use gungraun::prelude::*;
 ///
 /// #[binary_benchmark]
 /// fn bench_binary() -> gungraun::Command {
@@ -89,7 +90,7 @@ macro_rules! binary_benchmark_attribute {
 /// The [`crate::main`] macro has one form to run library benchmarks:
 ///
 /// ```rust
-/// # use gungraun::{main, library_benchmark_group, library_benchmark};
+/// # use gungraun::prelude::*;
 /// # #[library_benchmark]
 /// # fn bench_fibonacci() { }
 /// # library_benchmark_group!(
@@ -120,7 +121,7 @@ macro_rules! binary_benchmark_attribute {
 /// ```rust
 /// use std::hint::black_box;
 ///
-/// use gungraun::{library_benchmark, library_benchmark_group, main};
+/// use gungraun::prelude::*;
 ///
 /// fn fibonacci(n: u64) -> u64 {
 ///     match n {
@@ -148,9 +149,8 @@ macro_rules! binary_benchmark_attribute {
 /// via [`crate::Callgrind::args`], [`crate::Dhat::args`], ...:
 ///
 /// ```rust
-/// # use gungraun::{
-/// #   main, library_benchmark_group, library_benchmark, LibraryBenchmarkConfig, Callgrind
-/// # };
+/// # use gungraun::prelude::*;
+/// # use gungraun::Callgrind;
 /// # #[library_benchmark]
 /// # fn bench_fibonacci() { }
 /// # library_benchmark_group!(
@@ -181,7 +181,7 @@ macro_rules! binary_benchmark_attribute {
 ///
 /// ```rust
 /// # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-/// use gungraun::{binary_benchmark, binary_benchmark_group, main};
+/// use gungraun::prelude::*;
 ///
 /// #[binary_benchmark]
 /// #[bench::hello_world("hello world")]
@@ -643,9 +643,8 @@ macro_rules! main {
 /// The following top-level arguments are accepted (in this order):
 ///
 /// ```rust
-/// # use gungraun::{
-/// #     binary_benchmark, binary_benchmark_group, BinaryBenchmarkGroup, BinaryBenchmarkConfig,
-/// # };
+/// # use gungraun::prelude::*;
+/// # use gungraun::BinaryBenchmarkGroup;
 /// # fn run_setup() {}
 /// # fn run_teardown() {}
 /// # #[binary_benchmark]
@@ -659,7 +658,7 @@ macro_rules! main {
 ///     max_parallel = 1,
 ///     setup = run_setup(),
 ///     teardown = run_teardown(),
-///     benchmarks =  [ bench_1, bench_2 ]
+///     benchmarks = [bench_1, bench_2]
 /// );
 /// # fn main() {
 /// # my_group::my_group(&mut BinaryBenchmarkGroup::default());
@@ -695,7 +694,8 @@ macro_rules! main {
 ///
 /// ```rust
 /// # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-/// use gungraun::{binary_benchmark, binary_benchmark_group, BinaryBenchmarkGroup};
+/// use gungraun::prelude::*;
+/// use gungraun::BinaryBenchmarkGroup;
 ///
 /// #[binary_benchmark]
 /// #[bench::hello_world("hello world")]
@@ -740,7 +740,8 @@ macro_rules! main {
 ///
 /// ```rust
 /// # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-/// use gungraun::{binary_benchmark_group, Bench, BinaryBenchmark};
+/// use gungraun::prelude::*;
+/// use gungraun::{Bench, BinaryBenchmark};
 ///
 /// binary_benchmark_group!(
 ///     // All the other options from the `binary_benchmark_group` are used as usual
@@ -771,7 +772,8 @@ macro_rules! main {
 /// BinaryBenchmarkGroup|` if it resides in a separate function rather than the macro itself as in
 ///
 /// ```rust
-/// use gungraun::{binary_benchmark_group, Bench, BinaryBenchmark, BinaryBenchmarkGroup};
+/// use gungraun::prelude::*;
+/// use gungraun::{Bench, BinaryBenchmark, BinaryBenchmarkGroup};
 ///
 /// fn setup_my_group(group: &mut BinaryBenchmarkGroup) {
 ///     // Enjoy all the features of your IDE ...
@@ -803,10 +805,8 @@ macro_rules! main {
 ///
 /// ```rust
 /// # macro_rules! env { ($m:tt) => {{ "/some/path" }} }
-/// use gungraun::{
-///     binary_benchmark, binary_benchmark_attribute, binary_benchmark_group, Bench,
-///     BinaryBenchmark, BinaryBenchmarkGroup,
-/// };
+/// use gungraun::prelude::*;
+/// use gungraun::{binary_benchmark_attribute, Bench, BinaryBenchmark, BinaryBenchmarkGroup};
 ///
 /// #[binary_benchmark]
 /// #[bench::foo("foo")]
@@ -1346,7 +1346,7 @@ macro_rules! binary_benchmark_group {
 /// annotated with `#[library_benchmark]` ([`crate::library_benchmark`]).
 ///
 /// ```rust
-/// use gungraun::{library_benchmark, library_benchmark_group};
+/// use gungraun::prelude::*;
 ///
 /// #[library_benchmark]
 /// fn bench_something() -> u64 {
@@ -1367,7 +1367,7 @@ macro_rules! binary_benchmark_group {
 /// The following top-level arguments are accepted in this order:
 ///
 /// ```rust
-/// # use gungraun::{library_benchmark, library_benchmark_group, LibraryBenchmarkConfig};
+/// # use gungraun::prelude::*;
 /// # #[library_benchmark]
 /// # fn bench_1() {}
 /// # #[library_benchmark]

--- a/gungraun/tests/macros/binary_benchmark_attribute.rs
+++ b/gungraun/tests/macros/binary_benchmark_attribute.rs
@@ -1,9 +1,7 @@
 use std::sync::Mutex;
 
-use gungraun::{
-    __internal, binary_benchmark, binary_benchmark_attribute, Bench, BenchmarkId,
-    BinaryBenchmarkConfig,
-};
+use gungraun::prelude::*;
+use gungraun::{__internal, binary_benchmark_attribute, Bench, BenchmarkId};
 
 static CURRENT: Mutex<String> = Mutex::new(String::new());
 

--- a/gungraun/tests/ui/bin_bench/test_binary_benchmark_attribute_when_invalid.rs
+++ b/gungraun/tests/ui/bin_bench/test_binary_benchmark_attribute_when_invalid.rs
@@ -1,5 +1,5 @@
 mod test_when_config_has_wrong_type {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark(config = "string")]
     fn bench_binary() -> gungraun::Command {
@@ -8,7 +8,7 @@ mod test_when_config_has_wrong_type {
 }
 
 mod test_when_command_is_mut_ref {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn bench_binary() -> gungraun::Command {
@@ -17,7 +17,7 @@ mod test_when_command_is_mut_ref {
 }
 
 mod test_when_wrong_return_type_with_equal_name {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn bench_binary() -> gungraun::Command {
@@ -26,7 +26,7 @@ mod test_when_wrong_return_type_with_equal_name {
 }
 
 mod test_when_wrong_return_type_in_signature {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn bench_binary() -> String {
@@ -35,7 +35,7 @@ mod test_when_wrong_return_type_in_signature {
 }
 
 mod test_when_wrong_return_type_in_signature_with_equal_name {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn bench_binary() -> std::process::Command {
@@ -44,7 +44,7 @@ mod test_when_wrong_return_type_in_signature_with_equal_name {
 }
 
 mod test_when_setup_does_not_exist {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark(setup = does_not_exist())]
     fn bench_binary() -> gungraun::Command {
@@ -53,7 +53,7 @@ mod test_when_setup_does_not_exist {
 }
 
 mod test_when_setup_as_path_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn setup(_arg: usize) {}
 
@@ -64,7 +64,7 @@ mod test_when_setup_as_path_too_few_arguments {
 }
 
 mod test_when_teardown_does_not_exist {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark(teardown = does_not_exist())]
     fn bench_binary() -> gungraun::Command {
@@ -73,7 +73,7 @@ mod test_when_teardown_does_not_exist {
 }
 
 mod test_when_teardown_as_path_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn teardown(_arg: usize) {}
 

--- a/gungraun/tests/ui/bin_bench/test_binary_benchmark_bench_attribute_setup_teardown_when_invalid.rs
+++ b/gungraun/tests/ui/bin_bench/test_binary_benchmark_bench_attribute_setup_teardown_when_invalid.rs
@@ -1,5 +1,5 @@
 mod test_setup_as_path_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn setup(_arg: &str) {}
 
@@ -11,7 +11,7 @@ mod test_setup_as_path_too_few_arguments {
 }
 
 mod test_setup_as_path_too_many_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn setup(_arg: &str) {}
 
@@ -25,7 +25,7 @@ mod test_setup_as_path_too_many_arguments {
 }
 
 mod test_teardown_as_path_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn teardown(_arg: &str) {}
 
@@ -37,7 +37,7 @@ mod test_teardown_as_path_too_few_arguments {
 }
 
 mod test_teardown_as_path_too_many_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn teardown(_arg: &str) {}
 
@@ -51,7 +51,7 @@ mod test_teardown_as_path_too_many_arguments {
 }
 
 mod test_setup_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn setup(_arg: &str) {}
 
@@ -63,7 +63,7 @@ mod test_setup_too_few_arguments {
 }
 
 mod test_setup_too_many_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn setup(_arg: &str) {}
 
@@ -75,7 +75,7 @@ mod test_setup_too_many_arguments {
 }
 
 mod test_teardown_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn teardown(_arg: &str) {}
 
@@ -87,7 +87,7 @@ mod test_teardown_too_few_arguments {
 }
 
 mod test_teardown_too_many_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn teardown(_arg: &str) {}
 
@@ -99,7 +99,7 @@ mod test_teardown_too_many_arguments {
 }
 
 mod test_setup_too_many_teardown_too_many_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn teardown(_arg: &str) {}
     fn setup(_arg: &str) {}
@@ -112,7 +112,7 @@ mod test_setup_too_many_teardown_too_many_arguments {
 }
 
 mod test_setup_as_path_too_few_teardown_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     fn teardown(_arg: &str) {}
     fn setup(_arg: &str) {}

--- a/gungraun/tests/ui/bin_bench/test_binary_benchmark_bench_attribute_when_invalid.rs
+++ b/gungraun/tests/ui/bin_bench/test_binary_benchmark_bench_attribute_when_invalid.rs
@@ -1,5 +1,5 @@
 mod test_when_config_has_wrong_type {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(config = "string")]
@@ -9,7 +9,7 @@ mod test_when_config_has_wrong_type {
 }
 
 mod test_when_setup_not_exists {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(setup = setup())]
@@ -19,7 +19,7 @@ mod test_when_setup_not_exists {
 }
 
 mod test_when_setup_as_path_not_exists {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(setup = setup)]
@@ -29,7 +29,7 @@ mod test_when_setup_as_path_not_exists {
 }
 
 mod test_when_teardown_as_path_not_exists {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(teardown = teardown)]
@@ -39,7 +39,7 @@ mod test_when_teardown_as_path_not_exists {
 }
 
 mod test_when_args_has_no_value {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(args = )]
@@ -50,7 +50,7 @@ mod test_when_args_has_no_value {
 
 // TODO: THE SPAN SHOULD POINT TO #[bench] instead of #[binary_benchmark]
 mod test_when_args_not_present_but_expected {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some()]
@@ -60,7 +60,7 @@ mod test_when_args_not_present_but_expected {
 }
 
 mod test_when_args_has_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(args = ())]
@@ -70,7 +70,7 @@ mod test_when_args_has_too_few_arguments {
 }
 
 mod test_when_args_has_too_many_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(args = (1))]
@@ -80,7 +80,7 @@ mod test_when_args_has_too_many_arguments {
 }
 
 mod test_when_args_type_is_wrong {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(args = (1))]
@@ -90,7 +90,7 @@ mod test_when_args_type_is_wrong {
 }
 
 mod test_when_multiple_args_types_are_wrong {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(args = (1, 2))]
@@ -100,7 +100,7 @@ mod test_when_multiple_args_types_are_wrong {
 }
 
 mod test_when_list_has_too_many_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(1)]
@@ -110,7 +110,7 @@ mod test_when_list_has_too_many_arguments {
 }
 
 mod test_when_list_has_too_few_arguments {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(1)]
@@ -122,7 +122,7 @@ mod test_when_list_has_too_few_arguments {
 }
 
 mod test_when_list_type_is_wrong {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(1)]
@@ -132,7 +132,7 @@ mod test_when_list_type_is_wrong {
 }
 
 mod test_when_multiple_list_types_are_wrong {
-    use gungraun::binary_benchmark;
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     #[bench::some(1, 2)]

--- a/gungraun/tests/ui/bin_bench/test_binary_benchmark_group_when_invalid.rs
+++ b/gungraun/tests/ui/bin_bench/test_binary_benchmark_group_when_invalid.rs
@@ -1,11 +1,11 @@
 mod test_when_empty {
-    use gungraun::binary_benchmark_group;
+    use gungraun::prelude::*;
 
     binary_benchmark_group!();
 }
 
 mod test_when_no_name {
-    use gungraun::{binary_benchmark, binary_benchmark_group, Command};
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn bench() -> Command {
@@ -60,7 +60,7 @@ mod test_when_no_name {
 }
 
 mod test_low_level_when_no_benchmark {
-    use gungraun::binary_benchmark_group;
+    use gungraun::prelude::*;
 
     // comma syntax
     binary_benchmark_group!(
@@ -96,7 +96,7 @@ mod test_low_level_when_no_benchmark {
 }
 
 mod test_when_no_benchmark_argument {
-    use gungraun::binary_benchmark_group;
+    use gungraun::prelude::*;
 
     binary_benchmark_group!(name = some);
     binary_benchmark_group!(name = some,);
@@ -106,7 +106,7 @@ mod test_when_no_benchmark_argument {
 }
 
 mod test_when_max_parallel {
-    use gungraun::{binary_benchmark, binary_benchmark_group, Command};
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn some_func() -> Command {

--- a/gungraun/tests/ui/bin_bench/test_binary_benchmark_iter_when_invalid.rs
+++ b/gungraun/tests/ui/bin_bench/test_binary_benchmark_iter_when_invalid.rs
@@ -1,4 +1,4 @@
-use gungraun::binary_benchmark;
+use gungraun::prelude::*;
 
 mod test_when_together_with_other_main_parameter {
     use super::*;

--- a/gungraun/tests/ui/bin_bench/test_binary_benchmark_iter_when_valid.rs
+++ b/gungraun/tests/ui/bin_bench/test_binary_benchmark_iter_when_valid.rs
@@ -1,4 +1,4 @@
-use gungraun::{binary_benchmark, BinaryBenchmarkConfig};
+use gungraun::prelude::*;
 
 mod test_when_range {
     use super::*;

--- a/gungraun/tests/ui/bin_bench/test_binary_benchmark_valid_macros_rustfmt_able_syntax.rs
+++ b/gungraun/tests/ui/bin_bench/test_binary_benchmark_valid_macros_rustfmt_able_syntax.rs
@@ -1,7 +1,5 @@
-use gungraun::{
-    binary_benchmark, binary_benchmark_group, main, Bench, BinaryBenchmark, BinaryBenchmarkConfig,
-    Command,
-};
+use gungraun::prelude::*;
+use gungraun::{Bench, BinaryBenchmark};
 
 #[binary_benchmark]
 fn bench() -> Command {

--- a/gungraun/tests/ui/bin_bench/test_main_invalid_binary_benchmark_groups.rs
+++ b/gungraun/tests/ui/bin_bench/test_main_invalid_binary_benchmark_groups.rs
@@ -1,5 +1,5 @@
 mod test_when_binary_benchmark_group_is_not_a_group {
-    use gungraun::main;
+    use gungraun::prelude::*;
 
     fn some_func() {}
 
@@ -7,7 +7,7 @@ mod test_when_binary_benchmark_group_is_not_a_group {
 }
 
 mod test_when_config_is_not_a_binary_benchmark_config {
-    use gungraun::{binary_benchmark_group, main};
+    use gungraun::prelude::*;
 
     binary_benchmark_group!(
         name = some,
@@ -20,12 +20,12 @@ mod test_when_config_is_not_a_binary_benchmark_config {
 }
 
 mod test_when_no_group {
-    use gungraun::main;
+    use gungraun::prelude::*;
     main!(binary_benchmark_groups = );
 }
 
 mod test_when_invalid_syntax {
-    use gungraun::main;
+    use gungraun::prelude::*;
     main!(something);
 }
 

--- a/gungraun/tests/ui/bin_bench/test_main_valid_binary_benchmark_groups.rs
+++ b/gungraun/tests/ui/bin_bench/test_main_valid_binary_benchmark_groups.rs
@@ -1,5 +1,5 @@
 mod test_when_single_group {
-    use gungraun::{binary_benchmark, binary_benchmark_group, main};
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn some_bench() -> gungraun::Command {
@@ -11,7 +11,7 @@ mod test_when_single_group {
 }
 
 mod test_when_multiple_groups {
-    use gungraun::{binary_benchmark, binary_benchmark_group, main};
+    use gungraun::prelude::*;
 
     #[binary_benchmark]
     fn some_bench() -> gungraun::Command {

--- a/gungraun/tests/ui/bin_bench/test_main_valid_binary_benchmark_low_level_groups.rs
+++ b/gungraun/tests/ui/bin_bench/test_main_valid_binary_benchmark_low_level_groups.rs
@@ -1,5 +1,5 @@
 mod test_main_when_default_config {
-    use gungraun::{binary_benchmark_group, main, BinaryBenchmarkConfig};
+    use gungraun::prelude::*;
 
     binary_benchmark_group!(
         name = some,
@@ -15,7 +15,7 @@ mod test_main_when_default_config {
 }
 
 mod test_main_when_config_is_ref {
-    use gungraun::{binary_benchmark_group, main, BinaryBenchmarkConfig};
+    use gungraun::prelude::*;
 
     binary_benchmark_group!(
         name = some,
@@ -31,7 +31,8 @@ mod test_main_when_config_is_ref {
 }
 
 mod test_main_when_config_is_mut_ref {
-    use gungraun::{binary_benchmark_group, main, BinaryBenchmarkConfig, Cachegrind};
+    use gungraun::prelude::*;
+    use gungraun::Cachegrind;
 
     binary_benchmark_group!(
         name = some,
@@ -47,7 +48,7 @@ mod test_main_when_config_is_mut_ref {
 }
 
 mod test_main_when_no_config {
-    use gungraun::{binary_benchmark_group, main};
+    use gungraun::prelude::*;
 
     binary_benchmark_group!(
         name = some,
@@ -60,7 +61,7 @@ mod test_main_when_no_config {
 }
 
 mod test_main_when_multiple_groups {
-    use gungraun::{binary_benchmark_group, main};
+    use gungraun::prelude::*;
 
     binary_benchmark_group!(
         name = some,

--- a/gungraun/tests/ui/both/test_file_parameter_when_invalid.rs
+++ b/gungraun/tests/ui/both/test_file_parameter_when_invalid.rs
@@ -1,4 +1,4 @@
-use gungraun::{binary_benchmark, library_benchmark};
+use gungraun::prelude::*;
 
 mod test_empty_file {
     use super::*;

--- a/gungraun/tests/ui/both/test_when_invalid_const_generics.rs
+++ b/gungraun/tests/ui/both/test_when_invalid_const_generics.rs
@@ -1,4 +1,4 @@
-use gungraun::{binary_benchmark, library_benchmark, Command};
+use gungraun::prelude::*;
 
 mod test_consts_when_invalid_type {
     use super::*;

--- a/gungraun/tests/ui/both/test_with_valid_const_generics.rs
+++ b/gungraun/tests/ui/both/test_with_valid_const_generics.rs
@@ -1,4 +1,4 @@
-use gungraun::{binary_benchmark, library_benchmark, Command};
+use gungraun::prelude::*;
 
 mod test_consts_when_empty {
     use super::*;

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_group_when_invalid.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_group_when_invalid.rs
@@ -1,11 +1,11 @@
 mod test_when_empty {
-    use gungraun::library_benchmark_group;
+    use gungraun::prelude::*;
 
     library_benchmark_group!();
 }
 
 mod test_when_no_name {
-    use gungraun::{library_benchmark, library_benchmark_group};
+    use gungraun::prelude::*;
 
     #[library_benchmark]
     fn some_func() {}
@@ -37,7 +37,7 @@ mod test_when_no_name {
 }
 
 mod test_when_same_name {
-    use gungraun::{library_benchmark, library_benchmark_group};
+    use gungraun::prelude::*;
 
     #[library_benchmark]
     fn some_func() {}
@@ -47,13 +47,13 @@ mod test_when_same_name {
 }
 
 mod test_when_no_benchmark_argument {
-    use gungraun::library_benchmark_group;
+    use gungraun::prelude::*;
 
     library_benchmark_group!(name = some_name);
 }
 
 mod test_when_no_benchmarks {
-    use gungraun::library_benchmark_group;
+    use gungraun::prelude::*;
 
     // comma syntax
     library_benchmark_group!(
@@ -87,13 +87,13 @@ mod test_when_no_benchmarks {
 }
 
 mod test_when_unknown_token {
-    use gungraun::library_benchmark_group;
+    use gungraun::prelude::*;
 
     library_benchmark_group!(something);
 }
 
 mod test_when_max_parallel {
-    use gungraun::{library_benchmark, library_benchmark_group};
+    use gungraun::prelude::*;
 
     #[library_benchmark]
     fn some_func() {}

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_arguments.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_arguments.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 #[library_benchmark(wrong = LibraryBenchmarkConfig::default())]
 fn bench1() {}

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_attributes.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_attributes.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 #[library_benchmark]
 #[b]

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_arguments.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_arguments.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 // missing argument of the benchmark
 #[library_benchmark]

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_arguments_key_value.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_arguments_key_value.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 #[library_benchmark]
 #[bench::id(invalid = "value")]

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_arguments_when_config.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_arguments_when_config.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 #[library_benchmark]
 #[bench::id(config = "some")]

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_id.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_id.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 // missing id
 #[library_benchmark]

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_setup_and_teardown.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_bench_setup_and_teardown.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 fn setup_no_args() -> u64 {
     42

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_iter.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_iter.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 mod test_when_together_with_other_main_parameter {
     use super::*;

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_setup_and_teardown.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_invalid_setup_and_teardown.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 fn setup_no_args() -> u64 {
     42

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_bench_arguments.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_bench_arguments.rs
@@ -1,4 +1,4 @@
-use gungraun::{library_benchmark, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 #[bench::id1(42)]

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_benches_arguments.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_benches_arguments.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 fn some_setup(my: u8) -> u64 {
     my as u64 + 1

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_benchmark_function_patterns.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_benchmark_function_patterns.rs
@@ -1,4 +1,4 @@
-use gungraun::library_benchmark;
+use gungraun::prelude::*;
 
 mod test_when_reference {
     use super::*;

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_iter.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_iter.rs
@@ -1,4 +1,4 @@
-use gungraun::{library_benchmark, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 
 mod test_when_range {
     use super::*;

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_macros_rustfmt_able_syntax.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_macros_rustfmt_able_syntax.rs
@@ -1,4 +1,4 @@
-use gungraun::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 
 #[library_benchmark]
 fn bench() -> u64 {

--- a/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_setup_and_teardown.rs
+++ b/gungraun/tests/ui/lib_bench/test_library_benchmark_valid_setup_and_teardown.rs
@@ -1,4 +1,4 @@
-use gungraun::{library_benchmark, LibraryBenchmarkConfig};
+use gungraun::prelude::*;
 
 fn setup_no_args() -> u64 {
     42

--- a/gungraun/tests/ui/lib_bench/test_main_invalid_library_benchmark_groups.rs
+++ b/gungraun/tests/ui/lib_bench/test_main_invalid_library_benchmark_groups.rs
@@ -1,5 +1,5 @@
 mod test_when_library_benchmark_as_group {
-    use gungraun::{library_benchmark, main};
+    use gungraun::prelude::*;
     #[library_benchmark]
     fn some_func() {}
 
@@ -7,7 +7,7 @@ mod test_when_library_benchmark_as_group {
 }
 
 mod test_when_invalid_config {
-    use gungraun::{library_benchmark, library_benchmark_group, main};
+    use gungraun::prelude::*;
     #[library_benchmark]
     fn some_func() {}
 

--- a/gungraun/tests/ui/lib_bench/test_main_invalid_library_benchmark_setup_deprecated copy.rs
+++ b/gungraun/tests/ui/lib_bench/test_main_invalid_library_benchmark_setup_deprecated copy.rs
@@ -1,5 +1,5 @@
 mod test_when_deprecated {
-    use gungraun::main;
+    use gungraun::prelude::*;
     fn some_func() {}
     main!(run = cmd = "some", id = "id", args = []);
 }

--- a/gungraun/tests/ui/lib_bench/test_main_invalid_library_benchmark_setup_deprecated.rs
+++ b/gungraun/tests/ui/lib_bench/test_main_invalid_library_benchmark_setup_deprecated.rs
@@ -1,11 +1,11 @@
 mod test_deprecated_plain_functions {
-    use gungraun::main;
+    use gungraun::prelude::*;
     fn some_func() {}
     main!(some_func);
 }
 
 mod test_deprecated_callgrind_args_and_functions {
-    use gungraun::main;
+    use gungraun::prelude::*;
     fn some_func() {}
     main!(
         callgrind_args = "some";


### PR DESCRIPTION
This PR introduces a `prelude` module for convenient importing of commonly used items

- Add `gungraun::prelude` module exporting the most frequently used macros and structs:
  - Macros: `library_benchmark`, `library_benchmark_group`, `binary_benchmark`, `binary_benchmark_group`, `main!`
  - Structs: `LibraryBenchmarkConfig`, `BinaryBenchmarkConfig`, `Command`
- Update module-level docs to use prelude imports in examples
- Update all benchmark tests to use `use gungraun::prelude::*;` instead of individual imports

### Before
```rust
use gungraun::{library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig};
```

### After
```rust
use gungraun::prelude::*;
```

All changes are backwards compatible - the existing import style still works.

AI Tools were used to generate parts of the documentation and refactors