### PR TITLE
fix(slowdown): thread pools are not shutdown and are stuck in hot loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- ([#588](https://github.com/gungraun/gungraun/issues/588)): Fix thread pool
+  causing excessive CPU usage and slowdown when using multiple benchmark groups.
+  Thread pools were not being properly shut down leaving worker threads stuck in
+  hot loops.
+
 ## [0.18.0] - 2026-04-09
 
 ### Added

--- a/gungraun-runner/src/runner/tasks.rs
+++ b/gungraun-runner/src/runner/tasks.rs
@@ -175,7 +175,7 @@ struct Task {
 /// # Errors
 ///
 /// [`ThreadPool::new`] returns an error if `size` is less than 1.
-pub struct ThreadPool<T> {
+pub struct ThreadPool<T: Send + 'static> {
     force_shutdown: Arc<AtomicBool>,
     graceful_shutdown: Arc<AtomicBool>,
     job_queue: Arc<Injector<Job<T>>>,
@@ -607,7 +607,13 @@ impl<T: Send + 'static> ThreadPool<T> {
     }
 }
 
-impl<T> Iterator for ThreadPool<T> {
+impl<T: Send + 'static> Drop for ThreadPool<T> {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl<T: Send + 'static> Iterator for ThreadPool<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -739,5 +745,26 @@ mod tests {
 
         let next = thread_pool.next();
         assert!(next.is_some());
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(1))]
+    fn test_thread_pool_shutdown() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let mut pool: ThreadPool<()> = ThreadPool::new(4).unwrap();
+        for _ in 0..4 {
+            let counter_clone = counter.clone();
+            pool.execute(move |_| {
+                counter_clone.fetch_add(1, Ordering::Relaxed);
+            });
+        }
+
+        pool.shutdown();
+
+        assert_eq!(counter.load(Ordering::Relaxed), 4);
+        assert!(pool.tasks.iter().all(|t| t.thread.is_none()));
     }
 }


### PR DESCRIPTION
This pr fixes a performance regression (issue #588) where benchmarks ran much slower with version v0.18.0.

The `ThreadPool` struct lacked a `Drop` implementation. After a thread pool finished processing its benchmark group and went out of scope, worker threads remained alive, spinning in `std::hint::spin_loop()` waiting for work. With multiple benchmark groups creating thread pools, these threads accumulated, consuming excessive CPU and severely degrading performance.

Implemented `Drop` for `ThreadPool<T>` that calls `shutdown()` on drop, ensuring worker threads receive the `graceful_shutdown` signal and are properly joined before the pool is deallocated so the threads can't spin hot.

Related #588