### PR TITLE
chore(deps): Update rand to 0.8.6 to fix vulnaribility in dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,9 +1554,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]


### PR DESCRIPTION
rand is a transitive dependency of the valico package which is used in benchmark-tests and is therefore only a dev-dependency. No production code of this vulnaribility was affected.