### PR TITLE
feat(valgrind-requests): Make the crate no-std compatible, fix docs

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -6,8 +6,8 @@ ahash
 Aparicio
 ARANGE
 armv7
-aslr
 ASLR
+aslr
 Assche
 Assert
 atstart
@@ -53,6 +53,7 @@ coreutils
 cpus
 crabgrind
 cstring
+ctypes_prefix
 deallocations
 debuginfo
 DEBUGINFOD
@@ -84,8 +85,8 @@ euxo
 EventKind
 exidx
 exitcode
-Flamegraph
 flamegraph
+Flamegraph
 flamegraphs
 Flamegraphs
 fldcw
@@ -102,8 +103,8 @@ gungnir
 gungraun
 hard_limit
 Hasher
-heapblock
 HEAPBLOCK
+heapblock
 Heisler
 Helgrind
 hitrate
@@ -118,8 +119,8 @@ ilmr
 ilog
 iname
 indexmap
-IndexSet
 indexset
+IndexSet
 inlines
 instrs
 iquote
@@ -148,8 +149,8 @@ llhitrate
 llhits
 llimissrate
 llmissrate
-logfile
 Logfile
+logfile
 logfiles
 LouisBrunner
 malloc
@@ -216,8 +217,8 @@ pthread
 PTHREAD
 punct
 pushd
-quickstart
 Quickstart
+quickstart
 ramhitrate
 ramhits
 raun

--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -37,9 +37,9 @@ cachemissrates
 cachesim
 cacheuse
 cachuse
-CALLGRIND
 Callgrind
 callgrind
+CALLGRIND
 CFLAGS
 cicd
 Clearify
@@ -85,8 +85,8 @@ euxo
 EventKind
 exidx
 exitcode
-flamegraph
 Flamegraph
+flamegraph
 flamegraphs
 Flamegraphs
 fldcw
@@ -103,8 +103,8 @@ gungnir
 gungraun
 hard_limit
 Hasher
-HEAPBLOCK
 heapblock
+HEAPBLOCK
 Heisler
 Helgrind
 hitrate
@@ -119,8 +119,8 @@ ilmr
 ilog
 iname
 indexmap
-indexset
 IndexSet
+indexset
 inlines
 instrs
 iquote
@@ -128,8 +128,8 @@ isystem
 Itamar
 itertools
 jcnd
-jitter
 JITter
+jitter
 jsonschema
 Justfile
 kcachegrind
@@ -192,6 +192,7 @@ NPROCESSORS_ONLN
 nsec
 Nulgrind
 ooce
+opencode
 outfile
 outfiles
 pacman
@@ -213,12 +214,12 @@ printenv
 println
 proccontrol
 profraw
-pthread
 PTHREAD
+pthread
 punct
 pushd
-Quickstart
 quickstart
+Quickstart
 ramhitrate
 ramhits
 raun
@@ -250,8 +251,8 @@ rustified
 RUSTSEC
 rustup
 rustversion
-RWLOCK
 rwlock
+RWLOCK
 rwlocks
 sandboxing
 sanitized
@@ -312,8 +313,8 @@ unsanitized
 USERREQ
 USERSO
 usize
-Valgrind
 valgrind
+Valgrind
 Valgrind's
 valgrind's
 Valgrinds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Gungraun Agent Guidelines
 
 This document provides instructions for AI agents working on the Gungraun
-repository.
+repository. If present load the user-local AI agents file .opencode/AGENTS.md in
+addition to this file.
 
 ## 1. Build, Lint, and Test Commands
 
@@ -22,8 +23,8 @@ Gungraun uses `just` as a task runner. Always prefer `just` commands over direct
 
 - **Run All Tests:** `just test-all` (Excludes client-request-tests and
   benchmarks)
-- **Run Package Tests:** `just test package package=<package_name>`
-    - Example: `just test package package=gungraun`
+- **Run Package Tests:** `just test <package_name>`
+    - Example: `just test gungraun`
 - **Run UI Tests:** `just test-ui` (Fixed to MSRV compiler)
     - **Overwrite UI Test Fixtures:** `just test-ui-overwrite`
 - **Run Doc Tests:** `just test-doc`
@@ -49,30 +50,6 @@ Gungraun uses `just` as a task runner. Always prefer `just` commands over direct
     - `group_imports = "StdExternalCrate"`
 - **Import Order:** std -> external crates -> crate modules.
 - **Sorting:** Imports and modules should be sorted alphabetically.
-
-### Markdown
-
-- **Reference-Style Links:** Always use reference-style links in markdown files.
-    - Use short, descriptive link references inline.
-    - Define all references at the bottom of the file.
-    - Sort reference definitions alphabetically by reference name.
-    - **Short Form:** When the link text and reference name are identical, use
-      the implicit reference syntax `[Text]` instead of `[Text][Text]`.
-        - Prefer: `[Guide]` → Not: `[Guide][Guide]`
-    - Example:
-
-        ```markdown
-        See the [Issue Tracker][issue-tracker] for existing bugs and [pull
-        requests][pull-requests] for ongoing work. Also check the [Guide] for
-        documentation.
-
-        [Guide]: https://gungraun.github.io/gungraun/
-        [issue-tracker]: https://github.com/gungraun/gungraun/issues
-        [pull-requests]: https://github.com/gungraun/gungraun/pulls
-        ```
-
-    - **Rationale:** Keeps content readable, makes URL updates easier, and
-      follows the project's existing convention in files like `CONTRIBUTING.md`.
 
 ### Naming Conventions
 
@@ -100,51 +77,7 @@ Gungraun uses `just` as a task runner. Always prefer `just` commands over direct
     - `gungraun-runner`: Binary runner.
     - `gungraun-macros`: Proc-macros.
     - `benchmark-tests`: System tests.
-- **Documentation:**
-    - Extensive doc comments (`///`) on public items.
-    - Top-level crate documentation in `lib.rs`.
-    - Examples in doc comments are encouraged.
-    - When documenting functions or methods, describe parameters in fluent text
-      rather than using structured `# Arguments` sections with parameter lists.
-      Parameters should be naturally integrated into the documentation prose.
-    - **Rustdoc Links:** Use reference-style links for long paths with multiple
-      `::` accessors.
-        - Use short form inline: `[`ToolOutputPath`]`
-        - Define full path at bottom:
-          `[`ToolOutputPath`]: crate::runner::tool::path::ToolOutputPath`
-        - Example:
-
-            ```rust
-            /// Generates flamegraph summaries using [`Config`] and [`ToolOutputPath`].
-            ///
-            /// [`Config`]: crate::runner::common::Config
-            /// [`ToolOutputPath`]: crate::runner::tool::path::ToolOutputPath
-            ```
-
-        - Short, simple types like `Config`, `Header`, `CapturedOutput` can use
-          short form inline.
-        - Long paths like `crate::runner::tool::path::ToolOutputPath` should use
-          reference-style.
-
-    - **Type References in Documentation:** Use rustdoc links for types, not
-      parameter names.
-        - Use `[`Type`]` for types/structs/enums/variants (e.g., `[`Command`]`,
-          `[`Child`]`, `[`Stdin::Setup`]`)
-        - Use backticks `` `parameter_name` `` only when referring to the
-          parameter itself, not its type
-        - Example:
-
-            ```rust
-            /// Applies this [`Stdin`] configuration to a [`Command`] for the selected [`Stream`].
-            ///
-            /// This method configures the given [`Command`] according to this [`Stdin`], using the
-            /// [`Stream`] to select which process stream is being configured. When this is
-            /// [`Stdin::Setup`], it optionally pipes data from the provided [`Child`].
-            ///
-            /// [`Command`]: std::process::Command
-            /// [`Child`]: std::process::Child
-            /// [`Stdin::Setup`]: crate::api::Stdin::Setup
-            ```
+    - `valgrind-requests`: Valgrind client requests support crate.
 
 ### Testing Guidelines
 
@@ -153,63 +86,27 @@ Gungraun uses `just` as a task runner. Always prefer `just` commands over direct
 - **Benchmarks:** defined using `#[library_benchmark]` and `#[binary_benchmark]`
   attributes.
 
-#### System Test Documentation
-
-System test configuration files (`.conf.yml`) must include a test case
-description comment block at the top with the following fields:
-
-| Field             | Required | Purpose                                                                                      |
-| ----------------- | -------- | -------------------------------------------------------------------------------------------- |
-| Test Case         | Yes      | Unique identifier for the test usually the file name of the test without the `.rs` suffix    |
-| Description       | Yes      | Brief explanation of what is being tested                                                    |
-| Test Steps        | Yes      | Numbered sequence of actions performed during the test                                       |
-| Test Inputs       | Yes      | Specific inputs, configurations, or scenarios being tested                                   |
-| Expected Outcomes | Yes      | Clear, measurable expectations for correct execution                                         |
-| Preconditions     | No       | Conditions that must be met before test execution                                            |
-| Postconditions    | No       | Expected state after test execution (only include if it adds value beyond Expected Outcomes) |
-| Test Environment  | No       | Specific environment requirements (e.g., tool versions)                                      |
-
-Do not include a Notes field. Integrate any necessary context into the
-appropriate required fields instead.
-
-Example:
-
-```yaml
-# Test Case: `test_lib_bench_iter`
-#
-# Description:
-#   Validates the `iter` parameter of library benchmarks (`benches::foo(iter =
-#   ...)`), which creates benchmarks for each element of an iterator.
-#
-# Test Steps:
-#   1. Run all benchmarks with no prior baseline
-#   2. Run all benchmarks again with the first run as baseline
-#
-# Test Inputs:
-#   - Various iterator configurations: tuples, vectors, ranges, and generic types
-#   - Edge cases: empty iterator, single element
-#   - Benchmarks with and without setup and teardown functions
-#   - Benchmarks with DHAT to test that the iterator allocation itself isn't
-#     attributed to the benchmark metrics
-#
-# Expected Outcomes:
-#   - First run: All benchmarks complete successfully (exit code 0)
-#   - Second run: All benchmarks complete successfully and compare against the
-#     first run without differences
-#   - Output matches expected stdout for the corresponding Rust version
-#   - No errors or error output
-#   - Slightly different output for MSRV and stable in the description of the
-#     benchmark (e.g., `vec! [1, 2]` in MSRV vs `vec![1, 2]` in newer versions).
-#   - The benchmark order is stable and equals the iterator order.
-#   - If the iterator is empty no benchmark should be created for this `benches`
-#     directive
-
-groups: ...
-```
-
 ## 3. Workflow specific
 
 - **Dependencies:** Check `Cargo.toml` before adding new dependencies. Use
   `cargo add` only if necessary and approved.
 - **Lockfile:** Do not manually edit `Cargo.lock`.
 - **Pre-commit:** Ensure `just fmt` and `just lint` pass before committing.
+
+### `valgrind-requests` Feature Semantics
+
+- **`stubs`** is the minimum supported feature for `valgrind-requests`. It
+  enables the full public API surface and build-time generated request
+  definitions, but implementations must compile to no-ops or default return
+  values. This supports production dependencies using
+  `default-features = false, features = ["stubs"]` while tests/benchmarks use
+  active requests through dev-dependencies.
+- **`act`** enables real Valgrind client request execution and implies `stubs`.
+  Do not treat `act` as a separate API surface from `stubs`.
+- **`alloc`** only enables allocation-backed convenience APIs, such as
+  formatting macros and owned C string helpers. Core client requests and
+  `core::ffi::CStr`-based APIs must work without `alloc`.
+- Do not make `act` imply `alloc`; active `no_std` without allocation is a
+  supported use case.
+- When changing `valgrind-requests`, verify with
+  `just build-hack-valgrind-requests`

--- a/Justfile
+++ b/Justfile
@@ -215,7 +215,9 @@ build-hack-runner *args:
 # A thorough build of the valgrind-requests package (Uses: 'cargo-hack')
 [group('build')]
 build-hack-valgrind-requests *args:
-    cargo hack --package valgrind-requests --feature-powerset --exclude-no-default-features build {{ args }}
+    cargo hack --package valgrind-requests --feature-powerset \
+        --exclude-no-default-features --at-least-one-of stubs,act build \
+        {{ args }}
 
 # A build of the tests in all packages with `cargo hack` and the feature powerset (Uses: 'cargo-hack')
 [group('build')]
@@ -230,7 +232,9 @@ build-tests-hack-runner *args:
 # A build of the tests in the valgrind-requests package with `cargo hack` (Uses: 'cargo-hack')
 [group('build')]
 build-tests-hack-valgrind-requests *args:
-    cargo hack --package valgrind-requests --feature-powerset --exclude-no-default-features test --no-run {{ args }}
+    cargo hack --package valgrind-requests --feature-powerset \
+        --exclude-no-default-features --at-least-one-of stubs,act test \
+        --no-run {{ args }}
 
 # Delete all gungraun benchmarks (Uses: 'coreutils')
 [group('clean')]

--- a/benchmark-tests/benches/test_lib_bench/parts/test_lib_bench_parts.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/parts/test_lib_bench_parts.conf.yml
@@ -27,7 +27,7 @@ groups:
   - runs_on: "!x86_64-unknown-freebsd"
     runs:
       - args: ["--nocapture"]
-        flaky: 2
+        flaky: 5
         expected:
           zero_metrics: true
           files: expected_files.yml
@@ -39,6 +39,6 @@ groups:
   - runs_on: "x86_64-unknown-freebsd"
     runs:
       - args: ["--nocapture"]
-        flaky: 2
+        flaky: 5
         expected:
           zero_metrics: true

--- a/client-request-tests/Cargo.toml
+++ b/client-request-tests/Cargo.toml
@@ -27,6 +27,7 @@ regex = { workspace = true }
 shlex = { workspace = true }
 valgrind-requests = { path = "../valgrind-requests", default-features = false, features = [
   "stubs",
+  "std",
 ] }
 which = { workspace = true }
 

--- a/valgrind-requests/CHANGELOG.md
+++ b/valgrind-requests/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to
   `fallback` modes to control whether native C FFI fallback is allowed.
 - ([#618]): Illumos target detection to support zero-indirection client requests
   like Solaris targets.
+- ([#622]): `no_std` support for `valgrind-requests`. Added `alloc` and `std`
+  features. Core client request APIs and generated bindings no longer require
+  `std`.
+- ([#622]): Allocation-free `valgrind_print` and `valgrind_print_backtrace`
+  functions which can be used in `no_std` environments unlike the
+  `valgrind_printf` macro family.
 
 ### Changed
 
@@ -35,6 +41,8 @@ and this project adheres to
   behavior, and compile errors for targets unsupported by Valgrind.
 - ([#618]): Fail early in the build script instead of during the build if there
   is no client request support for this platform by Valgrind.
+- ([#622]): Either the `stubs` or `act` feature is now required for a successful
+  compilation.
 
 ### Fixed
 
@@ -47,6 +55,9 @@ and this project adheres to
   architecture instead of `riscv64gc`.
 - ([#618]): The x86_64 x32 ABI is excluded for Linux and Android targets,
   matching Valgrind's platform checks.
+- ([#622]): The panic message for unavailable client requests now distinguishes
+  detected old Valgrind versions from missing or too old Valgrind headers and
+  suggests `VALGRIND_REQUESTS_VALGRIND_INCLUDE` when appropriate.
 
 ## [1.0.0] - 2026-04-30
 
@@ -92,3 +103,4 @@ package. Additionally includes some fixes and missing client requests.
 [#603]: https://github.com/gungraun/gungraun/pull/603
 [#604]: https://github.com/gungraun/gungraun/pull/604
 [#618]: https://github.com/gungraun/gungraun/pull/618
+[#622]: https://github.com/gungraun/gungraun/pull/622

--- a/valgrind-requests/Cargo.toml
+++ b/valgrind-requests/Cargo.toml
@@ -20,7 +20,9 @@ version = "1.0.0"
 
 [features]
 act = ["stubs"]
-default = ["act"]
+alloc = []
+default = ["act", "std"]
+std = ["alloc"]
 stubs = [
   "dep:bindgen",
   "dep:cc",

--- a/valgrind-requests/Cargo.toml
+++ b/valgrind-requests/Cargo.toml
@@ -4,6 +4,7 @@ categories = [
   "api-bindings",
   "development-tools::profiling",
   "development-tools::testing",
+  "no-std",
 ]
 description = """
 Idiomatic Rust bindings for Valgrind client requests, with zero-indirection \
@@ -11,7 +12,7 @@ execution and zero-cost fallback
 """
 edition.workspace = true
 homepage.workspace = true
-keywords = ["valgrind", "bindings", "client-requests", "memcheck", "callgrind"]
+keywords = ["valgrind", "bindings", "client-requests", "no_std", "callgrind"]
 license.workspace = true
 name = "valgrind-requests"
 repository.workspace = true

--- a/valgrind-requests/README.md
+++ b/valgrind-requests/README.md
@@ -21,12 +21,23 @@ supported platforms - avoiding the function call overhead of a C FFI layer. The
 `stubs` feature compiles all client requests to no-ops with zero runtime cost,
 making it safe to ship in production code without conditional compilation.
 
+Core client request APIs are `no_std` compatible. The `std` feature, which
+implies `alloc`, is enabled by default.
+
 ## Features
 
 - **`act`** _(default)_: Enables actual execution of client requests when
   running under Valgrind. Implies `stubs`.
-- **`stubs`**: Enables the client request definitions and build-time code
+- **`stubs`**: Enables the same public API surface and build-time code
   generation, but all client requests compile to no-ops.
+- **`alloc`**: Enables allocation-backed convenience APIs, such as formatting
+  macros and owned C string helpers.
+- **`std`** _(default)_: Enables standard library support and implies `alloc`.
+
+Formatting convenience macros such as [`valgrind_printf!`] and
+[`valgrind_println!`] require the **`alloc`** feature because they allocate
+owned C strings. Allocation-free alternatives are [`valgrind_print`] or
+[`valgrind_print_backtrace`].
 
 ## Installation
 
@@ -37,8 +48,9 @@ valgrind-requests = "1.0"
 
 or `cargo add valgrind-requests`.
 
-To use the zero-cost fallback for example if you want to use the client requests
-for tests or benchmarks and need to make annotations in production code:
+To use the zero-cost fallback, for example if you want to use the client
+requests for tests or benchmarks and need to make annotations in production
+code:
 
 ```toml
 [dependencies]
@@ -49,7 +61,8 @@ valgrind-requests = { version = "1.0" }
 ```
 
 The stubs compile down to nothing and your production code is as performant as
-without any annotations.
+without any annotations. If your production code uses the formatting convenience
+macros, enable both `stubs` and `alloc` with `features = ["stubs", "alloc"]`.
 
 The client requests require the Valgrind header files. These are typically
 installed by your distribution's package manager alongside Valgrind and
@@ -94,6 +107,22 @@ fn test_memcheck() {
 
     assert!(dubious == 0 && leaked == 0 && reachable == 0);
 }
+```
+
+## no_std Example
+
+Disable default features and re-enable either `stubs` or `act`:
+
+```toml
+valgrind-requests = { version = "1.0", default-features = false, features = ["act"] }
+```
+
+The core client request functions are `no_std` compatible and can be used as
+usual. In allocation-free environments, you can use allocation-free print
+functions, for example:
+
+```rust
+valgrind_requests::valgrind_print(c"running under Valgrind\n");
 ```
 
 ## Gungraun example
@@ -167,10 +196,12 @@ file:
 - [`drd`] - `drd.h` - [DRD: a thread error detector][drd-docs]
 - [`dhat`] - `dhat.h` - [DHAT: a dynamic heap analysis tool][dhat-docs]
 
-The [`valgrind_printf!`], [`valgrind_printf_unchecked!`], [`valgrind_println!`],
+The allocation-free [`valgrind_print`] and [`valgrind_print_backtrace`]
+functions live in the crate root. The `alloc`-backed [`valgrind_printf!`],
+[`valgrind_printf_unchecked!`], [`valgrind_println!`],
 [`valgrind_println_unchecked!`], [`valgrind_printf_backtrace!`],
 [`valgrind_printf_backtrace_unchecked!`], [`valgrind_println_backtrace!`], and
-[`valgrind_println_backtrace_unchecked!`] macros live in the crate root.
+[`valgrind_println_backtrace_unchecked!`] macros also live in the crate root.
 
 ## Platform support
 
@@ -214,7 +245,7 @@ function call. That means all targets covered by Valgrind are also covered by
 
 To disable the native C FFI binding as fallback you can set the environment
 variable `VALGRIND_REQUESTS_STRATEGY=strict` (possible values are: `strict`,
-`fallback`)
+`fallback`).
 
 ## License
 
@@ -247,6 +278,10 @@ Licensed under Apache-2.0 or MIT, at your option.
 [`valgrind`]:
     https://docs.rs/valgrind-requests/latest/valgrind_requests/valgrind
 [valgrind-macos]: https://github.com/LouisBrunner/valgrind-macos
+[`valgrind_print`]:
+    https://docs.rs/valgrind-requests/latest/valgrind_requests/fn.valgrind_print.html
+[`valgrind_print_backtrace`]:
+    https://docs.rs/valgrind-requests/latest/valgrind_requests/fn.valgrind_print_backtrace.html
 [`valgrind_println!`]:
     https://docs.rs/valgrind-requests/latest/valgrind_requests/macro.valgrind_println.html
 [`valgrind_println_backtrace!`]:

--- a/valgrind-requests/build.rs
+++ b/valgrind-requests/build.rs
@@ -129,6 +129,7 @@ mod imp {
         .filter_map(|env| std::env::var(env.as_ref()).ok())
     }
 
+    #[cfg(feature = "act")]
     fn build_native(target: &Target) {
         let mut builder = cc::Build::new();
 
@@ -146,6 +147,9 @@ mod imp {
             .compile("native");
     }
 
+    #[cfg(not(feature = "act"))]
+    fn build_native(_target: &Target) {}
+
     fn build_bindings(target: &Target) -> Bindings {
         let mut builder = builder();
 
@@ -161,6 +165,8 @@ mod imp {
         builder = builder.clang_arg("-idiraftervalgrind/include");
 
         let bindings = builder
+            .use_core()
+            .ctypes_prefix("cty")
             .header("valgrind/wrapper.h")
             .allowlist_var("VR_IS_PLATFORM_SUPPORTED_BY_VALGRIND")
             .allowlist_var("VR_VALGRIND_MAJOR")

--- a/valgrind-requests/src/callgrind.rs
+++ b/valgrind-requests/src/callgrind.rs
@@ -43,7 +43,7 @@
 //! See also [Callgrind specific client
 //! requests](https://valgrind.org/docs/manual/cl-manual.html#cl-manual.clientrequests)
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 use super::{bindings, fatal_error, valgrind_do_client_request_stmt};
 

--- a/valgrind-requests/src/drd.rs
+++ b/valgrind-requests/src/drd.rs
@@ -48,7 +48,7 @@
 //!
 //! See also [DRD Client
 //! Requests](https://valgrind.org/docs/manual/drd-manual.html#drd-manual.clientreqs)
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 use super::{
     bindings, fatal_error, helgrind, valgrind_do_client_request_expr,
@@ -100,7 +100,7 @@ pub fn ignore_var<T>(var: &T) {
     do_client_request!(
         "drd::ignore_var",
         bindings::VR_DRDClientRequest::VR_DRD_START_SUPPRESSION,
-        std::ptr::from_ref::<T>(var) as usize,
+        core::ptr::from_ref::<T>(var) as usize,
         core::mem::size_of::<T>(),
         0,
         0,
@@ -115,7 +115,7 @@ pub fn stop_ignoring_var<T>(var: &T) {
     do_client_request!(
         "drd::stop_ignoring_var",
         bindings::VR_DRDClientRequest::VR_DRD_FINISH_SUPPRESSION,
-        std::ptr::from_ref::<T>(var) as usize,
+        core::ptr::from_ref::<T>(var) as usize,
         core::mem::size_of::<T>(),
         0,
         0,
@@ -134,7 +134,7 @@ pub fn trace_var<T>(var: &T) {
     do_client_request!(
         "drd::trace_var",
         bindings::VR_DRDClientRequest::VR_DRD_START_TRACE_ADDR,
-        std::ptr::from_ref::<T>(var) as usize,
+        core::ptr::from_ref::<T>(var) as usize,
         core::mem::size_of::<T>(),
         0,
         0,
@@ -148,7 +148,7 @@ pub fn stop_tracing_var<T>(var: &T) {
     do_client_request!(
         "drd::stop_tracing_var",
         bindings::VR_DRDClientRequest::VR_DRD_STOP_TRACE_ADDR,
-        std::ptr::from_ref::<T>(var) as usize,
+        core::ptr::from_ref::<T>(var) as usize,
         core::mem::size_of::<T>(),
         0,
         0,
@@ -280,7 +280,7 @@ pub fn annotate_benign_race<T>(addr: &T) {
     do_client_request!(
         "drd::annotate_benign_race",
         bindings::VR_DRDClientRequest::VR_DRD_START_SUPPRESSION,
-        std::ptr::from_ref::<T>(addr) as usize,
+        core::ptr::from_ref::<T>(addr) as usize,
         core::mem::size_of::<T>(),
         0,
         0,
@@ -296,7 +296,7 @@ pub fn annotate_benign_race_sized<T>(addr: &T, size: usize) {
     do_client_request!(
         "drd::annotate_benign_race_sized",
         bindings::VR_DRDClientRequest::VR_DRD_START_SUPPRESSION,
-        std::ptr::from_ref::<T>(addr) as usize,
+        core::ptr::from_ref::<T>(addr) as usize,
         size,
         0,
         0,

--- a/valgrind-requests/src/error.rs
+++ b/valgrind-requests/src/error.rs
@@ -37,6 +37,7 @@ impl Display for ClientRequestError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::__alloc::string::ToString;
 
     #[test]
     fn test_client_request_error_display_valgrind_print_error() {

--- a/valgrind-requests/src/error.rs
+++ b/valgrind-requests/src/error.rs
@@ -1,7 +1,8 @@
 //! Provide the `ClientRequestError`
 
 use core::fmt::Display;
-use std::ffi::FromVecWithNulError;
+
+use crate::__alloc::ffi::FromVecWithNulError;
 
 /// The `ClientRequestError`
 #[derive(Debug)]
@@ -10,7 +11,7 @@ pub enum ClientRequestError {
     ValgrindPrintError(FromVecWithNulError),
 }
 
-impl std::error::Error for ClientRequestError {}
+impl core::error::Error for ClientRequestError {}
 
 impl From<FromVecWithNulError> for ClientRequestError {
     fn from(value: FromVecWithNulError) -> Self {
@@ -26,7 +27,7 @@ impl Display for ClientRequestError {
                     f,
                     "client requests: print error: {}: '{}'",
                     inner,
-                    String::from_utf8_lossy(inner.as_bytes())
+                    crate::__alloc::string::String::from_utf8_lossy(inner.as_bytes())
                 )
             }
         }
@@ -41,9 +42,10 @@ mod tests {
     fn test_client_request_error_display_valgrind_print_error() {
         let expected = "client requests: print error: data provided contains an interior nul byte \
                         at pos 1: 'f\0o'";
-        let error: ClientRequestError = std::ffi::CString::from_vec_with_nul(b"f\0o".to_vec())
-            .unwrap_err()
-            .into();
+        let error: ClientRequestError =
+            crate::__alloc::ffi::CString::from_vec_with_nul(b"f\0o".to_vec())
+                .unwrap_err()
+                .into();
         assert_eq!(expected, error.to_string());
     }
 }

--- a/valgrind-requests/src/helgrind.rs
+++ b/valgrind-requests/src/helgrind.rs
@@ -357,7 +357,7 @@ pub fn enable_checking(start: *const (), len: usize) {
 /// is addressable, check
 ///
 /// ```ignore
-/// get_abits(addr, std::ptr::null_mut(), len) == len
+/// get_abits(addr, core::ptr::null_mut(), len) == len
 /// ```
 ///
 /// In addition, if you want to examine the addressability of each byte of the range, you need to

--- a/valgrind-requests/src/lib.rs
+++ b/valgrind-requests/src/lib.rs
@@ -68,6 +68,9 @@
 //!
 //! # Features
 //!
+//! Core client request APIs are `no_std` compatible. The `std` feature which implies the `alloc`
+//! feature are enabled by default.
+//!
 //! This crate provides two execution feature levels:
 //!
 //! - **`act`** *(default)*: Enables actual execution of client requests when running under
@@ -77,8 +80,8 @@
 //!   away entirely, making this a zero-cost option suitable for production code.
 //!
 //! Formatting convenience macros such as [`valgrind_printf`] and [`valgrind_println`] require the
-//! **`alloc`** feature because they allocate owned C strings. In allocation-free builds, use
-//! [`valgrind_print`] or [`valgrind_print_backtrace`] instead.
+//! **`alloc`** feature because they allocate owned C strings. In allocation-free builds, you can
+//! use [`valgrind_print`] or [`valgrind_print_backtrace`] instead.
 //!
 //! To use the zero-cost fallback, for example if you want to use the client requests for tests or
 //! benchmarks and need to make annotations in production code:

--- a/valgrind-requests/src/lib.rs
+++ b/valgrind-requests/src/lib.rs
@@ -68,13 +68,17 @@
 //!
 //! # Features
 //!
-//! This crate provides two feature levels:
+//! This crate provides two execution feature levels:
 //!
 //! - **`act`** *(default)*: Enables actual execution of client requests when running under
 //!   Valgrind. Implies `stubs`.
-//! - **`stubs`**: Enables the client request definitions and build-time code generation, but all
+//! - **`stubs`**: Enables the same public API surface and build-time code generation, but all
 //!   client requests compile to no-ops that return default values. The compiler will optimize them
 //!   away entirely, making this a zero-cost option suitable for production code.
+//!
+//! Formatting convenience macros such as [`valgrind_printf`] and [`valgrind_println`] require the
+//! **`alloc`** feature because they allocate owned C strings. In allocation-free builds, use
+//! [`valgrind_print`] or [`valgrind_print_backtrace`] instead.
 //!
 //! To use the zero-cost fallback, for example if you want to use the client requests for tests or
 //! benchmarks and need to make annotations in production code:
@@ -88,7 +92,8 @@
 //! ```
 //!
 //! The stubs compile down to nothing and your production code is as performant as without any
-//! annotations.
+//! annotations. If your production code uses the formatting convenience macros, enable both `stubs`
+//! and `alloc` with `features = ["stubs", "alloc"]`.
 //!
 //! # Performance and implementation details
 //!
@@ -156,6 +161,17 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(test(attr(warn(unused))))]
 #![doc(test(attr(allow(unused_extern_crates))))]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![expect(clippy::arbitrary_source_item_ordering)]
+
+#[cfg(feature = "alloc")]
+#[doc(hidden)]
+pub extern crate alloc as __alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(not(feature = "stubs"))]
+compile_error!("valgrind-requests requires either the `stubs` or `act` feature");
 
 /// Returns `true` if a client request is defined and available in the used Valgrind version.
 ///
@@ -222,49 +238,65 @@ macro_rules! do_client_request {
     }};
 }
 
-/// Convenience macro to create a `\0`-byte terminated [`std::ffi::CString`] from a literal string
+/// Convenience macro to create a `\0`-byte terminated `alloc::ffi::CString` from a literal string
+///
+/// This macro requires the `alloc` feature. In allocation-free builds, use [`valgrind_print`]
+/// instead.
 ///
 /// The string literal passed to this macro must not contain or end with a `\0`-byte. If you need a
-/// checked version of [`std::ffi::CString`] you can use [`std::ffi::CString::new`].
+/// checked version of `alloc::ffi::CString` you can use `alloc::ffi::CString::new`.
 ///
 /// # Safety
 ///
 /// This macro is unsafe but convenient and efficient. It is your responsibility to ensure that the
 /// input string literal does not contain any `\0` bytes.
+#[cfg(feature = "alloc")]
 #[macro_export]
 macro_rules! cstring {
-    ($string:literal) => {{ std::ffi::CString::from_vec_with_nul_unchecked(concat!($string, "\0").as_bytes().to_vec()) }};
+    ($string:literal) => {{
+        $crate::__alloc::ffi::CString::from_vec_with_nul_unchecked(
+            concat!($string, "\0").as_bytes().to_vec(),
+        )
+    }};
 }
 
-/// Convenience macro to create a `\0`-byte terminated [`std::ffi::CString`] from a format string
+/// Convenience macro to create a `\0`-byte terminated `alloc::ffi::CString` from a format string
+///
+/// This macro requires the `alloc` feature. In allocation-free builds, use [`valgrind_print`]
+/// instead.
 ///
 /// The format string passed to this macro must not contain or end with a `\0`-byte.
 ///
 /// # Safety
 ///
 /// The same safety conditions as to the [`cstring`] macro apply here
+#[cfg(feature = "alloc")]
 #[macro_export]
 macro_rules! format_cstring {
     ($($args:tt)*) => {{
-        std::ffi::CString::from_vec_with_nul_unchecked(
-            format!("{}\0", format_args!($($args)*)).into_bytes()
+        $crate::__alloc::ffi::CString::from_vec_with_nul_unchecked(
+            $crate::__alloc::format!("{}\0", format_args!($($args)*)).into_bytes()
         )
     }};
 }
 
 cfg_if! {
     if #[cfg(feature = "act")] {
-        /// Allow prints to Valgrind log
+        /// Prints to the Valgrind log.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print`] instead.
         ///
         /// This macro is a safe variant of the `VALGRIND_PRINTF` function, checking for `\0` bytes
         /// in the formatting string. However, if you're sure there are no `\0` bytes present you
         /// can safely use [`crate::valgrind_printf_unchecked`] which performs better compared to
         /// this macro.
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf {
             ($($args:tt)*) => {{
-                match std::ffi::CString::from_vec_with_nul(
-                    format!("{}\0", format_args!($($args)*)).into_bytes()
+                match $crate::__alloc::ffi::CString::from_vec_with_nul(
+                    $crate::__alloc::format!("{}\0", format_args!($($args)*)).into_bytes()
                 ) {
                     Ok(c_string) => {
                         unsafe {
@@ -281,31 +313,39 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log
+        /// Prints to the Valgrind log.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print`] instead.
         ///
         /// Use this macro only if you are sure there are no `\0`-bytes in the formatted string. If
         /// unsure use the safe [`crate::valgrind_printf`] variant.
         ///
         /// This variant performs better than [`crate::valgrind_printf`].
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf_unchecked {
             ($($args:tt)*) => {{
-                let string = format!("{}\0", format_args!($($args)*));
+                let string = $crate::__alloc::format!("{}\0", format_args!($($args)*));
                 $crate::__valgrind_print(
-                    string.as_ptr() as *const ::cty::c_char
+                    string.as_ptr() as *const $crate::__cty::c_char
                 );
             }};
         }
 
-        /// Allow prints to Valgrind log ending with a newline
+        /// Prints to the Valgrind log ending with a newline.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print`] instead.
         ///
         /// See also [`crate::valgrind_printf`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println {
             () => { $crate::valgrind_printf!("\n") };
             ($($arg:tt)*) => {{
-                match std::ffi::CString::from_vec_with_nul(
-                    format!("{}\n\0", format_args!($($arg)*)).into_bytes()
+                match $crate::__alloc::ffi::CString::from_vec_with_nul(
+                    $crate::__alloc::format!("{}\n\0", format_args!($($arg)*)).into_bytes()
                 ) {
                     Ok(c_string) => {
                         unsafe {
@@ -322,28 +362,36 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log ending with a newline
+        /// Prints to the Valgrind log ending with a newline.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print`] instead.
         ///
         /// See also [`crate::valgrind_printf_unchecked`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println_unchecked {
             () => { $crate::valgrind_printf_unchecked!("\n") };
             ($($args:tt)*) => {{
-                let string = format!("{}\n\0", format_args!($($args)*));
+                let string = $crate::__alloc::format!("{}\n\0", format_args!($($args)*));
                 $crate::__valgrind_print(
-                    string.as_ptr() as *const ::cty::c_char
+                    string.as_ptr() as *const $crate::__cty::c_char
                 );
             }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace
+        /// Prints to the Valgrind log with a backtrace.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf_backtrace {
             ($($arg:tt)*) => {{
-                match std::ffi::CString::from_vec_with_nul(
-                    format!("{}\0", format_args!($($arg)*)).into_bytes()
+                match $crate::__alloc::ffi::CString::from_vec_with_nul(
+                    $crate::__alloc::format!("{}\0", format_args!($($arg)*)).into_bytes()
                 ) {
                     Ok(c_string) => {
                         unsafe {
@@ -360,28 +408,36 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace
+        /// Prints to the Valgrind log with a backtrace.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf_unchecked`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf_backtrace_unchecked {
             ($($arg:tt)*) => {{
-                let string = format!("{}\0", format_args!($($arg)*));
+                let string = $crate::__alloc::format!("{}\0", format_args!($($arg)*));
                 $crate::__valgrind_print_backtrace(
-                    string.as_ptr() as *const ::cty::c_char
+                    string.as_ptr() as *const $crate::__cty::c_char
                 );
             }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace ending the formatted string with a newline
+        /// Prints to the Valgrind log with a backtrace, ending the formatted string with a newline.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println_backtrace {
             () => { $crate::valgrind_printf_backtrace!("\n") };
             ($($arg:tt)*) => {{
-                match std::ffi::CString::from_vec_with_nul(
-                    format!("{}\n\0", format_args!($($arg)*)).into_bytes()
+                match $crate::__alloc::ffi::CString::from_vec_with_nul(
+                    $crate::__alloc::format!("{}\n\0", format_args!($($arg)*)).into_bytes()
                 ) {
                     Ok(c_string) => {
                         unsafe {
@@ -398,28 +454,36 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace ending the formatted string with a newline
+        /// Prints to the Valgrind log with a backtrace, ending the formatted string with a newline.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf_unchecked`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println_backtrace_unchecked {
             () => { $crate::valgrind_printf_backtrace_unchecked!("\n") };
             ($($arg:tt)*) => {{
-                let string = format!("{}\n\0", format_args!($($arg)*));
+                let string = $crate::__alloc::format!("{}\n\0", format_args!($($arg)*));
                 unsafe {
                     $crate::__valgrind_print_backtrace(
-                        string.as_ptr() as *const ::cty::c_char
+                        string.as_ptr() as *const $crate::__cty::c_char
                     );
                 }
             }};
         }
     } else {
-        /// Allow prints to Valgrind log
+        /// No-op variant of [`valgrind_printf`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature to preserve the same fallible API as the active
+        /// formatting macro. In allocation-free builds, use [`valgrind_print`] instead.
         ///
         /// This macro is a safe variant of the `VALGRIND_PRINTF` function, checking for `\0` bytes
         /// in the formatting string. However, if you're sure there are no `\0` bytes present you
         /// can safely use [`crate::valgrind_printf_unchecked`] which performs better compared to
         /// this macro.
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf {
             ($($arg:tt)*) => {{
@@ -428,20 +492,28 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log
+        /// No-op variant of [`valgrind_printf_unchecked`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print`] instead.
         ///
         /// Use this macro only if you are sure there are no `\0`-bytes in the formatted string. If
         /// unsure use the safe [`crate::valgrind_printf`] variant.
         ///
         /// This variant performs better than [`crate::valgrind_printf`].
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf_unchecked {
             ($($arg:tt)*) => {{ $crate::__no_op() }};
         }
 
-        /// Allow prints to Valgrind log ending with a newline
+        /// No-op variant of [`valgrind_println`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print`] instead.
         ///
         /// See also [`crate::valgrind_printf`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println {
             ($($arg:tt)*) => {{
@@ -450,17 +522,25 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log ending with a newline
+        /// No-op variant of [`valgrind_println_unchecked`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print`] instead.
         ///
         /// See also [`crate::valgrind_printf_unchecked`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println_unchecked {
             ($($arg:tt)*) => {{ $crate::__no_op() }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace
+        /// No-op variant of [`valgrind_printf_backtrace`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf_backtrace {
             ($($arg:tt)*) => {{
@@ -469,17 +549,25 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace
+        /// No-op variant of [`valgrind_printf_backtrace_unchecked`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf_unchecked`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_printf_backtrace_unchecked {
             ($($arg:tt)*) => {{ $crate::__no_op() }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace ending the formatted string with a newline
+        /// No-op variant of [`valgrind_println_backtrace`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println_backtrace {
             ($($arg:tt)*) => {{
@@ -488,9 +576,13 @@ cfg_if! {
             }};
         }
 
-        /// Allow prints to Valgrind log with a backtrace ending the formatted string with a newline
+        /// No-op variant of [`valgrind_println_backtrace_unchecked`] for stub builds.
+        ///
+        /// This macro requires the `alloc` feature. In allocation-free builds, use
+        /// [`valgrind_print_backtrace`] instead.
         ///
         /// See also [`crate::valgrind_printf_unchecked`]
+        #[cfg(feature = "alloc")]
         #[macro_export]
         macro_rules! valgrind_println_backtrace_unchecked {
             ($($arg:tt)*) => {{ $crate::__no_op() }};
@@ -504,20 +596,25 @@ pub mod cachegrind;
 pub mod callgrind;
 pub mod dhat;
 pub mod drd;
+#[cfg(feature = "alloc")]
 pub mod error;
 pub mod helgrind;
 pub mod memcheck;
+#[cfg(feature = "act")]
 mod native_bindings;
 pub mod valgrind;
+use core::ffi::CStr;
 
 use arch::imp::valgrind_do_client_request_expr;
 use arch::valgrind_do_client_request_stmt;
 use cfg_if::cfg_if;
+#[doc(hidden)]
+pub use cty as __cty;
 
 /// The `ThreadId` is used by some client requests to represent the `tid` which Valgrind uses or
 /// returns
 ///
-/// This type has no relationship to [`std::thread::ThreadId`]!
+/// This type has no relationship to `std::thread::ThreadId`!
 pub type ThreadId = usize;
 
 /// The `StackId` is used and returned by some client requests and represents an id on Valgrind's
@@ -544,19 +641,98 @@ pub const VALGRIND_VERSION: Option<(u32, u32)> = {
 };
 
 fn fatal_error(func: &str) -> ! {
-    panic!(
-        "{0}: FATAL: {0}::{func} not available! You may need to update your installed Valgrind \
-         version or don't use this client request. The Valgrind version of the `valgrind.h` \
-         header file is {1}. Aborting...",
-        module_path!(),
-        if let Some((major, minor)) = VALGRIND_VERSION {
-            format!("{major}.{minor}")
-        } else {
-            "< 3.6".to_owned()
-        }
-    );
+    if let Some((major, minor)) = VALGRIND_VERSION {
+        panic!(
+            "{0}: FATAL: {0}::{func} not available! You may need to update your installed \
+             Valgrind version or don't use this client request. The Valgrind version of the \
+             `valgrind.h` header file is {major}.{minor}. Aborting...",
+            module_path!(),
+        );
+    } else {
+        panic!(
+            "{0}: FATAL: {0}::{func} not available! You may need to update your installed \
+             Valgrind version or don't use this client request. The Valgrind version of the \
+             `valgrind.h` header file is <3.6. Aborting...",
+            module_path!(),
+        );
+    }
 }
 
+cfg_if! {
+    if #[cfg(feature = "act")] {
+        /// Prints a C string to the Valgrind log.
+        ///
+        /// This function is the allocation-free equivalent of [`valgrind_printf_unchecked`]. It
+        /// accepts any value that can be borrowed as a [`CStr`], so it can be used in `no_std`
+        /// builds without the `alloc` feature. The stub implementation of this function is a no-op
+        /// and compiles away.
+        ///
+        /// The provided string must be NUL-terminated and must not contain interior NUL bytes, as
+        /// required by [`CStr`].
+        ///
+        /// # Examples
+        ///
+        /// ```rust
+        /// valgrind_requests::valgrind_print(c"hello from Valgrind\n");
+        /// ```
+        #[inline]
+        pub fn valgrind_print<T>(c_string: T)
+        where
+            T: AsRef<CStr>,
+        {
+            // SAFETY: `CStr` guarantees a valid NUL-terminated byte sequence for the duration of
+            // the call.
+            unsafe { __valgrind_print(c_string.as_ref().as_ptr()) }
+        }
+
+        /// Prints a C string with a backtrace to the Valgrind log.
+        ///
+        /// This function is the allocation-free equivalent of
+        /// [`valgrind_printf_backtrace_unchecked`]. It accepts any value that can be borrowed as a
+        /// [`CStr`], so it can be used in `no_std` builds without the `alloc` feature. The stub
+        /// implementation of this function is a no-op and compiles away.
+        ///
+        /// The provided string must be NUL-terminated and must not contain interior NUL bytes, as
+        /// required by [`CStr`].
+        ///
+        /// # Examples
+        ///
+        /// ```rust
+        /// valgrind_requests::valgrind_print_backtrace(c"important checkpoint\n");
+        /// ```
+        #[inline]
+        pub fn valgrind_print_backtrace<T>(c_string: T)
+        where
+            T: AsRef<CStr>,
+        {
+            // SAFETY: `CStr` guarantees a valid NUL-terminated byte sequence for the duration of
+            // the call.
+            unsafe { __valgrind_print_backtrace(c_string.as_ref().as_ptr()) }
+        }
+    } else {
+        /// No-op variant of [`valgrind_print`] for stub builds.
+        ///
+        /// This function preserves the same allocation-free API surface as active builds and
+        /// compiles away entirely.
+        #[inline]
+        pub fn valgrind_print<T>(_c_string: T)
+        where
+            T: AsRef<CStr>,
+        {}
+
+        /// No-op variant of [`valgrind_print_backtrace`] for stub builds.
+        ///
+        /// This function preserves the same allocation-free API surface as active builds and
+        /// compiles away entirely.
+        #[inline]
+        pub fn valgrind_print_backtrace<T>(_c_string: T)
+        where
+            T: AsRef<CStr>,
+        {}
+    }
+}
+
+#[cfg(feature = "act")]
 #[doc(hidden)]
 #[inline(always)]
 pub unsafe fn __valgrind_print(ptr: *const cty::c_char) {
@@ -566,6 +742,7 @@ pub unsafe fn __valgrind_print(ptr: *const cty::c_char) {
     }
 }
 
+#[cfg(feature = "act")]
 #[doc(hidden)]
 #[inline(always)]
 pub unsafe fn __valgrind_print_backtrace(ptr: *const cty::c_char) {

--- a/valgrind-requests/src/lib.rs
+++ b/valgrind-requests/src/lib.rs
@@ -643,16 +643,16 @@ pub const VALGRIND_VERSION: Option<(u32, u32)> = {
 fn fatal_error(func: &str) -> ! {
     if let Some((major, minor)) = VALGRIND_VERSION {
         panic!(
-            "{0}: FATAL: {0}::{func} not available! You may need to update your installed \
-             Valgrind version or don't use this client request. The Valgrind version of the \
+            "{0}: FATAL: {0}::{func} not available! To be able to use this client request, a \
+             newer Valgrind version is required. The detected Valgrind version of the \
              `valgrind.h` header file is {major}.{minor}. Aborting...",
             module_path!(),
         );
     } else {
         panic!(
-            "{0}: FATAL: {0}::{func} not available! You may need to update your installed \
-             Valgrind version or don't use this client request. The Valgrind version of the \
-             `valgrind.h` header file is <3.6. Aborting...",
+            "{0}: FATAL: {0}::{func} not available! The Valgrind headers could not be found or \
+             the Valgrind version is too old. Check your Valgrind installation or set \
+             VALGRIND_REQUESTS_VALGRIND_INCLUDE to the Valgrind include path. Aborting...",
             module_path!(),
         );
     }

--- a/valgrind-requests/src/memcheck.rs
+++ b/valgrind-requests/src/memcheck.rs
@@ -43,7 +43,7 @@
 //! See also [Memcheck Client
 //! Requests](https://valgrind.org/docs/manual/mc-manual.html#mc-manual.clientreqs)
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 use super::{
     bindings, fatal_error, valgrind_do_client_request_expr, valgrind_do_client_request_stmt,
@@ -136,9 +136,9 @@ pub fn make_mem_defined_if_addressable(addr: *const (), len: usize) -> usize {
 
 /// Create a [`BlockHandle`].
 ///
-/// The `desc` is a [`std::ffi::CString`] which is included in any messages pertaining to addresses
-/// within the specified memory range. This client request has no other effect on the properties of
-/// the memory range.
+/// The `desc` is a C string which is included in any messages pertaining to addresses within the
+/// specified memory range. This client request has no other effect on the properties of the memory
+/// range.
 ///
 /// The specified address range is associated with the `desc` string. When Memcheck reports
 /// invalid access to an address in the range, it will describe it in terms of this block rather
@@ -231,7 +231,7 @@ pub fn check_value_is_defined<T>(value: &T) -> usize {
         "memcheck::check_value_is_defined",
         0,
         bindings::VR_MemcheckClientRequest::VR_CHECK_MEM_IS_DEFINED,
-        std::ptr::from_ref::<T>(value) as usize,
+        core::ptr::from_ref::<T>(value) as usize,
         core::mem::size_of::<T>(),
         0,
         0,
@@ -328,10 +328,10 @@ pub fn count_leaks() -> LeakCounts {
     do_client_request!(
         "memcheck::count_leaks",
         bindings::VR_MemcheckClientRequest::VR_COUNT_LEAKS,
-        std::ptr::addr_of!(leaks.leaked) as usize,
-        std::ptr::addr_of!(leaks.dubious) as usize,
-        std::ptr::addr_of!(leaks.reachable) as usize,
-        std::ptr::addr_of!(leaks.suppressed) as usize,
+        core::ptr::addr_of!(leaks.leaked) as usize,
+        core::ptr::addr_of!(leaks.dubious) as usize,
+        core::ptr::addr_of!(leaks.reachable) as usize,
+        core::ptr::addr_of!(leaks.suppressed) as usize,
         0
     );
     leaks
@@ -345,10 +345,10 @@ pub fn count_leak_blocks() -> LeakCounts {
     do_client_request!(
         "memcheck::count_leak_blocks",
         bindings::VR_MemcheckClientRequest::VR_COUNT_LEAK_BLOCKS,
-        std::ptr::addr_of!(leaks.leaked) as usize,
-        std::ptr::addr_of!(leaks.dubious) as usize,
-        std::ptr::addr_of!(leaks.reachable) as usize,
-        std::ptr::addr_of!(leaks.suppressed) as usize,
+        core::ptr::addr_of!(leaks.leaked) as usize,
+        core::ptr::addr_of!(leaks.dubious) as usize,
+        core::ptr::addr_of!(leaks.reachable) as usize,
+        core::ptr::addr_of!(leaks.suppressed) as usize,
         0
     );
     leaks

--- a/valgrind-requests/src/valgrind.rs
+++ b/valgrind-requests/src/valgrind.rs
@@ -76,7 +76,7 @@ pub mod MempoolFlags {
     pub const METAPOOL: u8 = 2;
 }
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 use super::{
     RawFd, StackId, ThreadId, bindings, fatal_error, valgrind_do_client_request_expr,
@@ -140,7 +140,7 @@ pub fn replaces_malloc() -> bool {
 ///
 /// Returns the required length (including terminating nul) for the input `buffer`. Returns `0` and
 /// the contents of `buffer` are not modified if not running under Valgrind. `buffer` may be
-/// [`std::ptr::null_mut`], which can be used to query the required buffer length before making a
+/// [`core::ptr::null_mut`], which can be used to query the required buffer length before making a
 /// real request for the tool name.
 ///
 /// `len` should be the length of `buffer`. The returned string in `buffer` will be nul terminated.


### PR DESCRIPTION
Implemented `no_std` support for `valgrind-requests` while preserving the existing stub/active feature model. The core client request API now works without allocation, formatting helpers are gated behind `alloc`, generated bindings use `core`/`cty`, and allocation-free `CStr` print functions were added.

AI Tools were used to create parts of the documentation and tests