### PR TITLE
Set --vgdb=no by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ Gungraun uses `just` as a task runner. Always prefer `just` commands over direct
 
 - **Unit Tests:** Co-located in the same file or `mod tests` within the file.
 - **Integration Tests:** Located in `tests/` directory of the package.
+- **gungraun-runner Integration Tests:** Integration-style tests for
+  gungraun-runner live in `benchmark-tests/tests/`.
 - **Benchmarks:** defined using `#[library_benchmark]` and `#[binary_benchmark]`
   attributes.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ version = "0.18.2"
 dependencies = [
  "anyhow",
  "bincode-next",
+ "bon",
  "cargo_metadata",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bincode-next = { version = "2", default-features = false, features = [
   "std",
 ] }
 bindgen = { version = ">=0.69, <0.73" }
-bon = { version = "3" }
+bon = { version = "3.9" }
 cargo_metadata = { version = "0.20" }
 cc = { version = "1.0.100" }
 cfg-if = { version = "1" }
@@ -58,7 +58,7 @@ polonius-the-crab = { version = "0.5" }
 predicates = { version = "3" }
 pretty_assertions = "1.1"
 proc-macro-error2 = "2.0.1"
-proc-macro2 = "1.0.83"
+proc-macro2 = "1.0.88"
 quote = "1.0.35"
 regex = { version = "1.12" }
 rstest = { version = ">=0.17, <0.27", default-features = false }

--- a/gungraun-runner/Cargo.toml
+++ b/gungraun-runner/Cargo.toml
@@ -104,6 +104,7 @@ version-compare = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
 
 [dev-dependencies]
+bon = { workspace = true }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 serde_test = { workspace = true }

--- a/gungraun-runner/src/runner/cachegrind/args.rs
+++ b/gungraun-runner/src/runner/cachegrind/args.rs
@@ -1,44 +1,35 @@
 //! The module containing the command line arguments for Cachegrind
 
-use std::str::FromStr;
-
 use anyhow::Result;
-use log::{log_enabled, warn};
 
 use crate::api::{RawToolArgs, ValgrindTool};
 use crate::error::Error;
-use crate::runner::tool::args::{
-    FairSched, ToolArgs, Vgdb, defaults, is_ignored_argument, is_ignored_outfile_argument,
-};
+use crate::runner::tool::args::{ToolArgs, ValgrindArgs, defaults};
 use crate::util::{bool_to_yesno, yesno_to_bool};
 
 /// The command-line arguments
 #[derive(Debug, Clone)]
-pub struct Args {
+pub struct CachegrindArgs {
     cache_sim: bool,
     d1: String,
-    fair_sched: FairSched,
     i1: String,
     ll: String,
-    other: Vec<String>,
-    trace_children: bool,
-    verbose: bool,
-    vgdb: Vgdb,
+    valgrind: ValgrindArgs,
 }
 
-impl Args {
-    /// Try to create new `Args` from multiple [`RawToolArgs`]
-    pub fn try_from_raw_tool_args(args: &[&RawToolArgs]) -> Result<Self> {
+impl ToolArgs for CachegrindArgs {
+    fn try_from_raw_tool_args(tool: ValgrindTool, raw_tool_args: &[&RawToolArgs]) -> Result<Self> {
+        debug_assert_eq!(tool, ValgrindTool::Cachegrind);
+
         let mut default = Self::default();
-        default.try_update(args.iter().flat_map(|s| s.as_slice()))?;
+        default.try_update(raw_tool_args.iter().flat_map(|s| s.as_slice()))?;
         Ok(default)
     }
 
-    /// Try to update these `Args` from the contents of an iterator
-    pub fn try_update<'a, T: Iterator<Item = &'a String>>(&mut self, args: T) -> Result<()> {
+    fn try_update<'a, T: Iterator<Item = &'a String>>(&mut self, args: T) -> Result<()> {
         for arg in args {
-            let arg = arg.trim();
-            match arg.split_once('=').map(|(k, v)| (k.trim(), v.trim())) {
+            let trimmed = arg.trim();
+            match trimmed.split_once('=').map(|(k, v)| (k.trim(), v.trim())) {
                 Some(("--I1", value)) => value.clone_into(&mut self.i1),
                 Some(("--D1", value)) => value.clone_into(&mut self.d1),
                 Some(("--LL", value)) => value.clone_into(&mut self.ll),
@@ -47,70 +38,36 @@ impl Args {
                         Error::InvalidBoolArgument(key.to_owned(), value.to_owned())
                     })?;
                 }
-                Some((key @ "--trace-children", value)) => {
-                    self.trace_children = yesno_to_bool(value).ok_or_else(|| {
-                        Error::InvalidBoolArgument(key.to_owned(), value.to_owned())
-                    })?;
-                }
-                Some(("--fair-sched", value)) => {
-                    self.fair_sched = FairSched::from_str(value)?;
-                }
-                Some((arg, _)) if is_ignored_outfile_argument(arg) => warn!(
-                    "Ignoring cachegrind argument '{arg}': Output/Log files of tools are managed \
-                     by Gungraun",
-                ),
-                Some((arg, _)) if is_ignored_argument(arg) => {
-                    warn!("Ignoring cachegrind argument '{arg}'");
-                }
-                None if matches!(arg, "-v" | "--verbose") => self.verbose = true,
-                None if is_ignored_argument(arg) => {
-                    warn!("Ignoring cachegrind argument: '{arg}'");
-                }
-                None | Some(_) => self.other.push(arg.to_owned()),
+                None | Some(_) => self.valgrind.try_update(std::iter::once(arg))?,
             }
         }
         Ok(())
     }
 }
 
-impl Default for Args {
+impl Default for CachegrindArgs {
     fn default() -> Self {
         Self {
             i1: defaults::I1.into(),
             d1: defaults::D1.into(),
             ll: defaults::LL.into(),
             cache_sim: defaults::CACHE_SIM,
-            verbose: log_enabled!(log::Level::Debug),
-            other: Vec::default(),
-            trace_children: defaults::TRACE_CHILDREN,
-            fair_sched: defaults::FAIR_SCHED,
-            vgdb: defaults::VGDB,
+            valgrind: ValgrindArgs::new(ValgrindTool::Cachegrind),
         }
     }
 }
 
-impl From<Args> for ToolArgs {
-    fn from(mut value: Args) -> Self {
-        let mut other = vec![
+impl From<CachegrindArgs> for ValgrindArgs {
+    fn from(value: CachegrindArgs) -> Self {
+        let mut valgrind = value.valgrind;
+        let other = vec![
             format!("--I1={}", &value.i1),
             format!("--D1={}", &value.d1),
             format!("--LL={}", &value.ll),
             format!("--cache-sim={}", bool_to_yesno(value.cache_sim)),
         ];
-        other.append(&mut value.other);
+        valgrind.other.extend(other);
 
-        Self {
-            tool: ValgrindTool::Cachegrind,
-            output_paths: Vec::default(),
-            log_path: Option::default(),
-            xtree_path: Option::default(),
-            xleak_path: Option::default(),
-            error_exitcode: defaults::ERROR_EXIT_CODE_OTHER_TOOL.into(),
-            verbose: value.verbose,
-            trace_children: value.trace_children,
-            fair_sched: value.fair_sched,
-            vgdb: value.vgdb,
-            other,
-        }
+        valgrind
     }
 }

--- a/gungraun-runner/src/runner/cachegrind/args.rs
+++ b/gungraun-runner/src/runner/cachegrind/args.rs
@@ -8,7 +8,7 @@ use log::{log_enabled, warn};
 use crate::api::{RawToolArgs, ValgrindTool};
 use crate::error::Error;
 use crate::runner::tool::args::{
-    FairSched, ToolArgs, defaults, is_ignored_argument, is_ignored_outfile_argument,
+    FairSched, ToolArgs, Vgdb, defaults, is_ignored_argument, is_ignored_outfile_argument,
 };
 use crate::util::{bool_to_yesno, yesno_to_bool};
 
@@ -23,6 +23,7 @@ pub struct Args {
     other: Vec<String>,
     trace_children: bool,
     verbose: bool,
+    vgdb: Vgdb,
 }
 
 impl Args {
@@ -55,12 +56,15 @@ impl Args {
                     self.fair_sched = FairSched::from_str(value)?;
                 }
                 Some((arg, _)) if is_ignored_outfile_argument(arg) => warn!(
-                    "Ignoring Cachegrind argument '{arg}': Output/Log files of tools are managed \
+                    "Ignoring cachegrind argument '{arg}': Output/Log files of tools are managed \
                      by Gungraun",
                 ),
+                Some((arg, _)) if is_ignored_argument(arg) => {
+                    warn!("Ignoring cachegrind argument '{arg}'");
+                }
                 None if matches!(arg, "-v" | "--verbose") => self.verbose = true,
                 None if is_ignored_argument(arg) => {
-                    warn!("Ignoring Cachegrind argument: '{arg}'");
+                    warn!("Ignoring cachegrind argument: '{arg}'");
                 }
                 None | Some(_) => self.other.push(arg.to_owned()),
             }
@@ -80,6 +84,7 @@ impl Default for Args {
             other: Vec::default(),
             trace_children: defaults::TRACE_CHILDREN,
             fair_sched: defaults::FAIR_SCHED,
+            vgdb: defaults::VGDB,
         }
     }
 }
@@ -104,6 +109,7 @@ impl From<Args> for ToolArgs {
             verbose: value.verbose,
             trace_children: value.trace_children,
             fair_sched: value.fair_sched,
+            vgdb: value.vgdb,
             other,
         }
     }

--- a/gungraun-runner/src/runner/cachegrind/args.rs
+++ b/gungraun-runner/src/runner/cachegrind/args.rs
@@ -8,7 +8,7 @@ use crate::runner::tool::args::{ToolArgs, ValgrindArgs, defaults};
 use crate::util::{bool_to_yesno, yesno_to_bool};
 
 /// The command-line arguments
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachegrindArgs {
     cache_sim: bool,
     d1: String,
@@ -69,5 +69,157 @@ impl From<CachegrindArgs> for ValgrindArgs {
         valgrind.other.extend(other);
 
         valgrind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bon::builder;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::runner::tool::args::FairSched;
+
+    fn default_cachegrind_other_args() -> Vec<String> {
+        strings([
+            "--I1=32768,8,64",
+            "--D1=32768,8,64",
+            "--LL=8388608,16,64",
+            "--cache-sim=yes",
+        ])
+    }
+
+    fn strings<const N: usize>(args: [&str; N]) -> Vec<String> {
+        args.into_iter().map(str::to_owned).collect()
+    }
+
+    #[builder(finish_fn = "fixture")]
+    pub fn valgrind_args_f(
+        i1: Option<&str>,
+        fair_sched: Option<FairSched>,
+        other: Option<Vec<String>>,
+    ) -> ValgrindArgs {
+        let mut args = ValgrindArgs::new(ValgrindTool::Cachegrind);
+        if let Some(value) = i1 {
+            args.other.push(format!("--I1={value}"));
+        }
+        if let Some(value) = fair_sched {
+            args.fair_sched = value;
+        }
+        if let Some(value) = other {
+            args.other.extend(value);
+        }
+
+        args
+    }
+
+    #[builder(finish_fn = "fixture")]
+    pub fn cachegrind_args_f(
+        i1: Option<&str>,
+        d1: Option<&str>,
+        ll: Option<&str>,
+        cache_sim: Option<bool>,
+        valgrind: Option<ValgrindArgs>,
+    ) -> CachegrindArgs {
+        let mut args = CachegrindArgs::default();
+        if let Some(value) = i1 {
+            args.i1 = value.to_owned();
+        }
+        if let Some(value) = d1 {
+            args.d1 = value.to_owned();
+        }
+        if let Some(value) = ll {
+            args.ll = value.to_owned();
+        }
+        if let Some(value) = cache_sim {
+            args.cache_sim = value;
+        }
+        if let Some(value) = valgrind {
+            args.valgrind = value;
+        }
+
+        args
+    }
+
+    #[rstest]
+    #[case::i1(&["--I1=some"], cachegrind_args_f().i1("some").fixture())]
+    #[case::d1(&["--D1=some"], cachegrind_args_f().d1("some").fixture())]
+    #[case::ll(&["--LL=some"], cachegrind_args_f().ll("some").fixture())]
+    #[case::cache_sim(&["--cache-sim=no"], cachegrind_args_f().cache_sim(false).fixture())]
+    #[case::valgrind_special(
+        &["--fair-sched=no"],
+        cachegrind_args_f()
+            .valgrind(valgrind_args_f().fair_sched(FairSched::No).fixture())
+            .fixture()
+    )]
+    #[case::valgrind_other(
+        &["--some-arg=yes"],
+        cachegrind_args_f()
+            .valgrind(valgrind_args_f().other(vec!["--some-arg=yes".to_owned()]).fixture())
+            .fixture()
+    )]
+    fn test_try_from_raw_tool_args(#[case] args: &[&str], #[case] expected: CachegrindArgs) {
+        let actual = CachegrindArgs::try_from_raw_tool_args(
+            ValgrindTool::Cachegrind,
+            &[&RawToolArgs::from_iter(args)],
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_cachegrind_args_defaults() {
+        let expected = valgrind_args_f()
+            .other(default_cachegrind_other_args())
+            .fixture();
+
+        let actual = ValgrindArgs::from(cachegrind_args_f().fixture());
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_cachegrind_args_when_tool_specific_values() {
+        let args = cachegrind_args_f()
+            .i1("i1")
+            .d1("d1")
+            .ll("ll")
+            .cache_sim(false)
+            .fixture();
+        let expected = valgrind_args_f()
+            .other(strings(["--I1=i1", "--D1=d1", "--LL=ll", "--cache-sim=no"]))
+            .fixture();
+
+        let actual = ValgrindArgs::from(args);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_cachegrind_args_when_valgrind_args_then_appends_tool_specific_last() {
+        let args = cachegrind_args_f()
+            .i1("tool")
+            .valgrind(
+                valgrind_args_f()
+                    .fair_sched(FairSched::No)
+                    .other(strings(["--unknown=yes", "--I1=generic"]))
+                    .fixture(),
+            )
+            .fixture();
+        let expected = valgrind_args_f()
+            .fair_sched(FairSched::No)
+            .other(strings([
+                "--unknown=yes",
+                "--I1=generic",
+                "--I1=tool",
+                "--D1=32768,8,64",
+                "--LL=8388608,16,64",
+                "--cache-sim=yes",
+            ]))
+            .fixture();
+
+        let actual = ValgrindArgs::from(args);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/gungraun-runner/src/runner/callgrind/args.rs
+++ b/gungraun-runner/src/runner/callgrind/args.rs
@@ -1,21 +1,18 @@
 //! The module containing the command line arguments for callgrind
 use std::collections::VecDeque;
-use std::str::FromStr;
 
 use anyhow::Result;
-use log::{log_enabled, warn};
+use log::warn;
 
 use crate::api::{RawToolArgs, ValgrindTool};
 use crate::error::Error;
-use crate::runner::tool::args::{
-    FairSched, ToolArgs, Vgdb, defaults, is_ignored_argument, is_ignored_outfile_argument,
-};
+use crate::runner::tool::args::{ToolArgs, ValgrindArgs, defaults};
 use crate::util::{bool_to_yesno, yesno_to_bool};
 
 /// The command-line arguments
 #[expect(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
-pub struct Args {
+pub struct CallgrindArgs {
     cache_sim: bool,
     /// --combine-dumps is currently not supported by the Callgrind parsers, so we print a warning
     combine_dumps: bool,
@@ -24,30 +21,26 @@ pub struct Args {
     d1: String,
     dump_instr: bool,
     dump_line: bool,
-    fair_sched: FairSched,
     i1: String,
     ll: String,
-    other: Vec<String>,
     separate_threads: bool,
     toggle_collect: VecDeque<String>,
-    trace_children: bool,
-    verbose: bool,
-    vgdb: Vgdb,
+    valgrind_args: ValgrindArgs,
 }
 
-impl Args {
-    /// Try to create new `Args` from multiple [`RawToolArgs`]
-    pub fn try_from_raw_tool_args(args: &[&RawToolArgs]) -> Result<Self> {
+impl ToolArgs for CallgrindArgs {
+    fn try_from_raw_tool_args(tool: ValgrindTool, raw_tool_args: &[&RawToolArgs]) -> Result<Self> {
+        debug_assert_eq!(tool, ValgrindTool::Cachegrind);
+
         let mut default = Self::default();
-        default.try_update(args.iter().flat_map(|s| s.as_slice()))?;
+        default.try_update(raw_tool_args.iter().flat_map(|s| s.as_slice()))?;
         Ok(default)
     }
 
-    /// Try to update these `Args` from the contents of an iterator
-    pub fn try_update<'a, T: Iterator<Item = &'a String>>(&mut self, args: T) -> Result<()> {
+    fn try_update<'a, T: Iterator<Item = &'a String>>(&mut self, args: T) -> Result<()> {
         for arg in args {
-            let arg = arg.trim();
-            match arg.split_once('=').map(|(k, v)| (k.trim(), v.trim())) {
+            let trimmed = arg.trim();
+            match trimmed.split_once('=').map(|(k, v)| (k.trim(), v.trim())) {
                 Some(("--I1", value)) => value.clone_into(&mut self.i1),
                 Some(("--D1", value)) => value.clone_into(&mut self.d1),
                 Some(("--LL", value)) => value.clone_into(&mut self.ll),
@@ -69,18 +62,10 @@ impl Args {
                         Error::InvalidBoolArgument(key.to_owned(), value.to_owned())
                     })?;
                 }
-                Some((key @ "--trace-children", value)) => {
-                    self.trace_children = yesno_to_bool(value).ok_or_else(|| {
-                        Error::InvalidBoolArgument(key.to_owned(), value.to_owned())
-                    })?;
-                }
                 Some((key @ "--separate-threads", value)) => {
                     self.separate_threads = yesno_to_bool(value).ok_or_else(|| {
                         Error::InvalidBoolArgument(key.to_owned(), value.to_owned())
                     })?;
-                }
-                Some(("--fair-sched", value)) => {
-                    self.fair_sched = FairSched::from_str(value)?;
                 }
                 Some((
                     key @ ("--combine-dumps" | "--compress-strings" | "--compress-pos"),
@@ -88,25 +73,14 @@ impl Args {
                 )) => {
                     warn!("Ignoring unsupported callgrind argument: '{key}={value}'");
                 }
-                Some((arg, _)) if is_ignored_outfile_argument(arg) => warn!(
-                    "Ignoring callgrind argument '{arg}': Output/Log files of tools are managed \
-                     by Gungraun",
-                ),
-                Some((arg, _)) if is_ignored_argument(arg) => {
-                    warn!("Ignoring callgrind argument '{arg}'");
-                }
-                None if matches!(arg, "-v" | "--verbose") => self.verbose = true,
-                None if is_ignored_argument(arg) => {
-                    warn!("Ignoring callgrind argument: '{arg}'");
-                }
-                None | Some(_) => self.other.push(arg.to_owned()),
+                None | Some(_) => self.valgrind_args.try_update(std::iter::once(arg))?,
             }
         }
         Ok(())
     }
 }
 
-impl Default for Args {
+impl Default for CallgrindArgs {
     fn default() -> Self {
         Self {
             // Set some reasonable cache sizes. The exact sizes matter less than having fixed sizes,
@@ -119,22 +93,19 @@ impl Default for Args {
             compress_pos: defaults::COMPRESS_POS,
             compress_strings: defaults::COMPRESS_STRINGS,
             combine_dumps: defaults::COMBINE_DUMPS,
-            verbose: log_enabled!(log::Level::Debug),
             dump_line: defaults::DUMP_LINE,
             dump_instr: defaults::DUMP_INSTR,
             toggle_collect: VecDeque::default(),
-            other: Vec::default(),
-            trace_children: defaults::TRACE_CHILDREN,
             separate_threads: defaults::SEPARATE_THREADS,
-            fair_sched: defaults::FAIR_SCHED,
-            vgdb: defaults::VGDB,
+            valgrind_args: ValgrindArgs::new(ValgrindTool::Callgrind),
         }
     }
 }
 
-impl From<Args> for ToolArgs {
-    fn from(mut value: Args) -> Self {
-        let mut other = vec![
+impl From<CallgrindArgs> for ValgrindArgs {
+    fn from(value: CallgrindArgs) -> Self {
+        let mut valgrind = value.valgrind_args;
+        let other = vec![
             format!("--I1={}", &value.i1),
             format!("--D1={}", &value.d1),
             format!("--LL={}", &value.ll),
@@ -152,27 +123,14 @@ impl From<Args> for ToolArgs {
                 bool_to_yesno(value.separate_threads)
             ),
         ];
-        other.append(
-            &mut value
+        valgrind.other.extend(other);
+        valgrind.other.extend(
+            value
                 .toggle_collect
-                .iter()
-                .map(|s| format!("--toggle-collect={s}"))
-                .collect::<Vec<String>>(),
+                .into_iter()
+                .map(|s| format!("--toggle-collect={s}")),
         );
-        other.append(&mut value.other);
 
-        Self {
-            tool: ValgrindTool::Callgrind,
-            output_paths: Vec::default(),
-            log_path: Option::default(),
-            xtree_path: Option::default(),
-            xleak_path: Option::default(),
-            error_exitcode: defaults::ERROR_EXIT_CODE_OTHER_TOOL.into(),
-            verbose: value.verbose,
-            trace_children: value.trace_children,
-            fair_sched: value.fair_sched,
-            vgdb: value.vgdb,
-            other,
-        }
+        valgrind
     }
 }

--- a/gungraun-runner/src/runner/callgrind/args.rs
+++ b/gungraun-runner/src/runner/callgrind/args.rs
@@ -8,7 +8,7 @@ use log::{log_enabled, warn};
 use crate::api::{RawToolArgs, ValgrindTool};
 use crate::error::Error;
 use crate::runner::tool::args::{
-    FairSched, ToolArgs, defaults, is_ignored_argument, is_ignored_outfile_argument,
+    FairSched, ToolArgs, Vgdb, defaults, is_ignored_argument, is_ignored_outfile_argument,
 };
 use crate::util::{bool_to_yesno, yesno_to_bool};
 
@@ -32,6 +32,7 @@ pub struct Args {
     toggle_collect: VecDeque<String>,
     trace_children: bool,
     verbose: bool,
+    vgdb: Vgdb,
 }
 
 impl Args {
@@ -91,6 +92,9 @@ impl Args {
                     "Ignoring callgrind argument '{arg}': Output/Log files of tools are managed \
                      by Gungraun",
                 ),
+                Some((arg, _)) if is_ignored_argument(arg) => {
+                    warn!("Ignoring callgrind argument '{arg}'");
+                }
                 None if matches!(arg, "-v" | "--verbose") => self.verbose = true,
                 None if is_ignored_argument(arg) => {
                     warn!("Ignoring callgrind argument: '{arg}'");
@@ -123,6 +127,7 @@ impl Default for Args {
             trace_children: defaults::TRACE_CHILDREN,
             separate_threads: defaults::SEPARATE_THREADS,
             fair_sched: defaults::FAIR_SCHED,
+            vgdb: defaults::VGDB,
         }
     }
 }
@@ -166,6 +171,7 @@ impl From<Args> for ToolArgs {
             verbose: value.verbose,
             trace_children: value.trace_children,
             fair_sched: value.fair_sched,
+            vgdb: value.vgdb,
             other,
         }
     }

--- a/gungraun-runner/src/runner/callgrind/args.rs
+++ b/gungraun-runner/src/runner/callgrind/args.rs
@@ -11,7 +11,7 @@ use crate::util::{bool_to_yesno, yesno_to_bool};
 
 /// The command-line arguments
 #[expect(clippy::struct_excessive_bools)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallgrindArgs {
     cache_sim: bool,
     /// --combine-dumps is currently not supported by the Callgrind parsers, so we print a warning
@@ -30,7 +30,7 @@ pub struct CallgrindArgs {
 
 impl ToolArgs for CallgrindArgs {
     fn try_from_raw_tool_args(tool: ValgrindTool, raw_tool_args: &[&RawToolArgs]) -> Result<Self> {
-        debug_assert_eq!(tool, ValgrindTool::Cachegrind);
+        debug_assert_eq!(tool, ValgrindTool::Callgrind);
 
         let mut default = Self::default();
         default.try_update(raw_tool_args.iter().flat_map(|s| s.as_slice()))?;
@@ -132,5 +132,236 @@ impl From<CallgrindArgs> for ValgrindArgs {
         );
 
         valgrind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use bon::builder;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::runner::tool::args::FairSched;
+
+    fn default_callgrind_other_args() -> Vec<String> {
+        strings([
+            "--I1=32768,8,64",
+            "--D1=32768,8,64",
+            "--LL=8388608,16,64",
+            "--cache-sim=yes",
+            "--compress-strings=no",
+            "--compress-pos=no",
+            "--dump-line=yes",
+            "--dump-instr=no",
+            "--combine-dumps=no",
+            "--separate-threads=yes",
+        ])
+    }
+
+    fn strings<const N: usize>(args: [&str; N]) -> Vec<String> {
+        args.into_iter().map(str::to_owned).collect()
+    }
+
+    #[builder(finish_fn = "fixture")]
+    pub fn valgrind_args_f(
+        i1: Option<&str>,
+        fair_sched: Option<FairSched>,
+        other: Option<Vec<String>>,
+    ) -> ValgrindArgs {
+        let mut args = ValgrindArgs::new(ValgrindTool::Callgrind);
+        if let Some(value) = i1 {
+            args.other.push(format!("--I1={value}"));
+        }
+        if let Some(value) = fair_sched {
+            args.fair_sched = value;
+        }
+        if let Some(value) = other {
+            args.other.extend(value);
+        }
+
+        args
+    }
+
+    #[builder(finish_fn = "fixture")]
+    pub fn callgrind_args_f(
+        i1: Option<&str>,
+        d1: Option<&str>,
+        ll: Option<&str>,
+        cache_sim: Option<bool>,
+        toggle_collect: Option<VecDeque<String>>,
+        dump_instr: Option<bool>,
+        dump_line: Option<bool>,
+        separate_threads: Option<bool>,
+        valgrind_args: Option<ValgrindArgs>,
+    ) -> CallgrindArgs {
+        let mut args = CallgrindArgs::default();
+        if let Some(value) = i1 {
+            args.i1 = value.to_owned();
+        }
+        if let Some(value) = d1 {
+            args.d1 = value.to_owned();
+        }
+        if let Some(value) = ll {
+            args.ll = value.to_owned();
+        }
+        if let Some(value) = cache_sim {
+            args.cache_sim = value;
+        }
+        if let Some(value) = toggle_collect {
+            args.toggle_collect = value;
+        }
+        if let Some(value) = dump_instr {
+            args.dump_instr = value;
+        }
+        if let Some(value) = dump_line {
+            args.dump_line = value;
+        }
+        if let Some(value) = separate_threads {
+            args.separate_threads = value;
+        }
+        if let Some(value) = valgrind_args {
+            args.valgrind_args = value;
+        }
+
+        args
+    }
+
+    #[rstest]
+    #[case::i1(&["--I1=some"], callgrind_args_f().i1("some").fixture())]
+    #[case::d1(&["--D1=some"], callgrind_args_f().d1("some").fixture())]
+    #[case::ll(&["--LL=some"], callgrind_args_f().ll("some").fixture())]
+    #[case::cache_sim(&["--cache-sim=no"], callgrind_args_f().cache_sim(false).fixture())]
+    #[case::toggle_collect(
+        &["--toggle-collect=main"],
+        callgrind_args_f()
+            .toggle_collect(VecDeque::from(["main".to_owned()]))
+            .fixture()
+    )]
+    #[case::dump_instr(&["--dump-instr=yes"], callgrind_args_f().dump_instr(true).fixture())]
+    #[case::dump_line(&["--dump-line=no"], callgrind_args_f().dump_line(false).fixture())]
+    #[case::separate_threads(
+        &["--separate-threads=no"],
+        callgrind_args_f().separate_threads(false).fixture()
+    )]
+    #[case::combine_dumps_is_ignored(&["--combine-dumps=yes"], callgrind_args_f().fixture())]
+    #[case::compress_strings_is_ignored(
+        &["--compress-strings=yes"],
+        callgrind_args_f().fixture()
+    )]
+    #[case::compress_pos_is_ignored(&["--compress-pos=yes"], callgrind_args_f().fixture())]
+    #[case::valgrind_special(
+        &["--fair-sched=no"],
+        callgrind_args_f()
+            .valgrind_args(valgrind_args_f().fair_sched(FairSched::No).fixture())
+            .fixture()
+    )]
+    #[case::valgrind_other(
+        &["--some-arg=yes"],
+        callgrind_args_f()
+            .valgrind_args(valgrind_args_f().other(vec!["--some-arg=yes".to_owned()]).fixture())
+            .fixture()
+    )]
+    fn test_try_from_raw_tool_args(#[case] args: &[&str], #[case] expected: CallgrindArgs) {
+        let actual = CallgrindArgs::try_from_raw_tool_args(
+            ValgrindTool::Callgrind,
+            &[&RawToolArgs::from_iter(args)],
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_callgrind_args_when_defaults() {
+        let expected = valgrind_args_f()
+            .other(default_callgrind_other_args())
+            .fixture();
+
+        let actual = ValgrindArgs::from(callgrind_args_f().fixture());
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_callgrind_args_when_tool_specific_values() {
+        let args = callgrind_args_f()
+            .i1("i1")
+            .d1("d1")
+            .ll("ll")
+            .cache_sim(false)
+            .dump_line(false)
+            .dump_instr(true)
+            .separate_threads(false)
+            .fixture();
+        let expected = valgrind_args_f()
+            .other(strings([
+                "--I1=i1",
+                "--D1=d1",
+                "--LL=ll",
+                "--cache-sim=no",
+                "--compress-strings=no",
+                "--compress-pos=no",
+                "--dump-line=no",
+                "--dump-instr=yes",
+                "--combine-dumps=no",
+                "--separate-threads=no",
+            ]))
+            .fixture();
+
+        let actual = ValgrindArgs::from(args);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_callgrind_args_when_toggle_collect() {
+        let args = callgrind_args_f()
+            .toggle_collect(VecDeque::from(["main".to_owned(), "helper".to_owned()]))
+            .fixture();
+        let mut other = default_callgrind_other_args();
+        other.extend(strings([
+            "--toggle-collect=main",
+            "--toggle-collect=helper",
+        ]));
+        let expected = valgrind_args_f().other(other).fixture();
+
+        let actual = ValgrindArgs::from(args);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_callgrind_args_when_valgrind_args_then_appends_tool_specific_last() {
+        let args = callgrind_args_f()
+            .i1("tool")
+            .valgrind_args(
+                valgrind_args_f()
+                    .fair_sched(FairSched::No)
+                    .other(strings(["--unknown=yes", "--I1=generic"]))
+                    .fixture(),
+            )
+            .fixture();
+        let expected = valgrind_args_f()
+            .fair_sched(FairSched::No)
+            .other(strings([
+                "--unknown=yes",
+                "--I1=generic",
+                "--I1=tool",
+                "--D1=32768,8,64",
+                "--LL=8388608,16,64",
+                "--cache-sim=yes",
+                "--compress-strings=no",
+                "--compress-pos=no",
+                "--dump-line=yes",
+                "--dump-instr=no",
+                "--combine-dumps=no",
+                "--separate-threads=yes",
+            ]))
+            .fixture();
+
+        let actual = ValgrindArgs::from(args);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/gungraun-runner/src/runner/tool/args.rs
+++ b/gungraun-runner/src/runner/tool/args.rs
@@ -432,3 +432,125 @@ pub fn is_ignored_argument(arg: &str) -> bool {
             | "--vgdb"
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use bon::builder;
+    use rstest::rstest;
+
+    use super::*;
+
+    fn assert_contains_args<const N: usize>(actual: &[OsString], expected: [&str; N]) {
+        for expected in expected {
+            assert!(
+                actual.iter().any(|arg| arg.to_string_lossy() == expected),
+                "expected serialized arg {expected}"
+            );
+        }
+    }
+
+    fn strings<const N: usize>(args: [&str; N]) -> Vec<String> {
+        args.into_iter().map(str::to_owned).collect()
+    }
+
+    #[builder(finish_fn = "fixture")]
+    pub fn valgrind_args_f(
+        tool: Option<ValgrindTool>,
+        error_exitcode: Option<&str>,
+        fair_sched: Option<FairSched>,
+        other: Option<Vec<String>>,
+        trace_children: Option<bool>,
+        verbose: Option<bool>,
+    ) -> ValgrindArgs {
+        let mut args = ValgrindArgs::new(tool.unwrap_or(ValgrindTool::Memcheck));
+        if let Some(value) = error_exitcode {
+            args.error_exitcode = value.to_owned();
+        }
+        if let Some(value) = fair_sched {
+            args.fair_sched = value;
+        }
+        if let Some(value) = other {
+            args.other.extend(value);
+        }
+        if let Some(value) = trace_children {
+            args.trace_children = value;
+        }
+        if let Some(value) = verbose {
+            args.verbose = value;
+        }
+
+        args
+    }
+
+    #[rstest]
+    #[case::error_exitcode(
+        &["--error-exitcode=99"],
+        valgrind_args_f().error_exitcode("99").fixture()
+    )]
+    #[case::trace_children(
+        &["--trace-children=no"],
+        valgrind_args_f().trace_children(false).fixture()
+    )]
+    #[case::fair_sched(
+        &["--fair-sched=no"],
+        valgrind_args_f().fair_sched(FairSched::No).fixture()
+    )]
+    #[case::long_verbose(&["--verbose"], valgrind_args_f().verbose(true).fixture())]
+    #[case::short_verbose(&["-v"], valgrind_args_f().verbose(true).fixture())]
+    #[case::vgdb_is_ignored(&["--vgdb=yes"], valgrind_args_f().fixture())]
+    #[case::outfile_is_ignored(&["--log-file=some"], valgrind_args_f().fixture())]
+    #[case::other(
+        &["--some-arg=yes"],
+        valgrind_args_f()
+            .other(strings(["--some-arg=yes"]))
+            .fixture()
+    )]
+    fn test_try_from_raw_tool_args(#[case] args: &[&str], #[case] expected: ValgrindArgs) {
+        let actual = ValgrindArgs::try_from_raw_tool_args(
+            ValgrindTool::Memcheck,
+            &[&RawToolArgs::from_iter(args)],
+        )
+        .unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_to_vec_when_generic_args_then_forces_vgdb_no() {
+        let args = valgrind_args_f()
+            .error_exitcode("99")
+            .fair_sched(FairSched::No)
+            .trace_children(false)
+            .fixture();
+
+        let actual = args.to_vec();
+
+        assert_contains_args(
+            &actual,
+            [
+                "--tool=memcheck",
+                "--error-exitcode=99",
+                "--trace-children=no",
+                "--fair-sched=no",
+                "--vgdb=no",
+            ],
+        );
+    }
+
+    #[test]
+    fn test_to_vec_when_verbose_and_other_args() {
+        let args = valgrind_args_f()
+            .verbose(true)
+            .other(strings(["--some-arg=yes", "--another-some-arg"]))
+            .fixture();
+
+        let actual = args.to_vec();
+
+        assert_contains_args(
+            &actual,
+            ["--verbose", "--some-arg=yes", "--another-some-arg"],
+        );
+    }
+}

--- a/gungraun-runner/src/runner/tool/args.rs
+++ b/gungraun-runner/src/runner/tool/args.rs
@@ -1,4 +1,4 @@
-//! The module containing all elements for [`ToolArgs`]
+//! The module containing all elements for [`ValgrindArgs`]
 
 /// Module containing the Gungraun defaults for the command line arguments of all tools
 #[expect(missing_docs)]
@@ -77,9 +77,20 @@ pub enum Vgdb {
     Full,
 }
 
+/// Common parsing behavior for Valgrind tool arguments.
+pub trait ToolArgs: Sized {
+    /// Try to create new arguments from multiple [`RawToolArgs`].
+    fn try_from_raw_tool_args(tool: ValgrindTool, raw_tool_args: &[&RawToolArgs]) -> Result<Self>;
+
+    /// Try to update these arguments from the contents of an iterator.
+    fn try_update<'a, T>(&mut self, args: T) -> Result<()>
+    where
+        T: Iterator<Item = &'a String>;
+}
+
 /// The arguments to pass to the Valgrind tool
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ToolArgs {
+pub struct ValgrindArgs {
     /// The error exit code for error checking tools like `Memcheck`
     pub error_exitcode: String,
     /// The --fair-sched argument
@@ -130,13 +141,54 @@ impl FromStr for FairSched {
     }
 }
 
-impl ToolArgs {
-    /// Try to create a new `ToolArgs` from multiple `RawArgs`
-    pub fn try_from_raw_tool_args(
-        tool: ValgrindTool,
-        raw_tool_args: &[&RawToolArgs],
-    ) -> Result<Self> {
-        let mut tool_args = Self {
+impl ToolArgs for ValgrindArgs {
+    fn try_from_raw_tool_args(tool: ValgrindTool, raw_tool_args: &[&RawToolArgs]) -> Result<Self> {
+        let mut tool_args = Self::new(tool);
+
+        tool_args.try_update(raw_tool_args.iter().flat_map(|args| args.as_slice()))?;
+
+        Ok(tool_args)
+    }
+
+    fn try_update<'a, T: Iterator<Item = &'a String>>(&mut self, args: T) -> Result<()> {
+        for arg in args {
+            let arg = arg.trim();
+            match arg.split_once('=').map(|(k, v)| (k.trim(), v.trim())) {
+                Some(("--error-exitcode", value)) => {
+                    value.clone_into(&mut self.error_exitcode);
+                }
+                Some((key @ "--trace-children", value)) => {
+                    self.trace_children = yesno_to_bool(value).ok_or_else(|| {
+                        Error::InvalidBoolArgument(key.to_owned(), value.to_owned())
+                    })?;
+                }
+                Some(("--fair-sched", value)) => {
+                    self.fair_sched = FairSched::from_str(value)?;
+                }
+                Some((arg, _)) if is_ignored_outfile_argument(arg) => warn!(
+                    "Ignoring {} argument '{arg}': Output/Log files of tools are managed by \
+                     Gungraun",
+                    self.tool.id()
+                ),
+                Some((arg, _)) if is_ignored_argument(arg) => {
+                    warn!("Ignoring {} argument '{arg}'", self.tool.id());
+                }
+                None if matches!(arg, "-v" | "--verbose") => self.verbose = true,
+                None if is_ignored_argument(arg) => {
+                    warn!("Ignoring {} argument '{arg}'", self.tool.id());
+                }
+                None | Some(_) => self.other.push(arg.to_owned()),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ValgrindArgs {
+    /// Create a new `ValgrindArgs` with the defaults for this tool.
+    pub fn new(tool: ValgrindTool) -> Self {
+        Self {
             tool,
             output_paths: Vec::default(),
             log_path: Option::default(),
@@ -157,44 +209,10 @@ impl ToolArgs {
             trace_children: defaults::TRACE_CHILDREN,
             fair_sched: defaults::FAIR_SCHED,
             vgdb: defaults::VGDB,
-        };
-
-        for args in raw_tool_args {
-            for arg in args.as_slice() {
-                let arg = arg.trim();
-                match arg.split_once('=').map(|(k, v)| (k.trim(), v.trim())) {
-                    Some(("--error-exitcode", value)) => {
-                        value.clone_into(&mut tool_args.error_exitcode);
-                    }
-                    Some((key @ "--trace-children", value)) => {
-                        tool_args.trace_children = yesno_to_bool(value).ok_or_else(|| {
-                            Error::InvalidBoolArgument(key.to_owned(), value.to_owned())
-                        })?;
-                    }
-                    Some(("--fair-sched", value)) => {
-                        tool_args.fair_sched = FairSched::from_str(value)?;
-                    }
-                    Some((arg, _)) if is_ignored_outfile_argument(arg) => warn!(
-                        "Ignoring {} argument '{arg}': Output/Log files of tools are managed by \
-                         Gungraun",
-                        tool.id()
-                    ),
-                    Some((arg, _)) if is_ignored_argument(arg) => {
-                        warn!("Ignoring {} argument '{arg}'", tool.id());
-                    }
-                    None if matches!(arg, "-v" | "--verbose") => tool_args.verbose = true,
-                    None if is_ignored_argument(arg) => {
-                        warn!("Ignoring {} argument '{arg}'", tool.id());
-                    }
-                    None | Some(_) => tool_args.other.push(arg.to_owned()),
-                }
-            }
         }
-
-        Ok(tool_args)
     }
 
-    /// Set the output file argument depending on the tool of this `ToolArgs`
+    /// Set the output file argument depending on the tool of this `ValgrindArgs`
     pub fn set_output_arg(
         &mut self,
         output_path: &ToolOutputPath,

--- a/gungraun-runner/src/runner/tool/args.rs
+++ b/gungraun-runner/src/runner/tool/args.rs
@@ -3,7 +3,7 @@
 /// Module containing the Gungraun defaults for the command line arguments of all tools
 #[expect(missing_docs)]
 pub mod defaults {
-    use super::FairSched;
+    use super::{FairSched, Vgdb};
 
     ////////////////////////////////////////////////////
     // Shared defaults between cachegrind and callgrind
@@ -37,6 +37,7 @@ pub mod defaults {
     pub const TRACE_CHILDREN: bool = true;
     pub const FAIR_SCHED: FairSched = FairSched::Try;
     pub const VERBOSE: bool = false;
+    pub const VGDB: Vgdb = Vgdb::No;
     ////////////////////////////////////////////////////
 }
 
@@ -65,6 +66,17 @@ pub enum FairSched {
     Try,
 }
 
+/// The possible values for --vgdb
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Vgdb {
+    /// Corresponds to `yes`
+    Yes,
+    /// Corresponds to `no`
+    No,
+    /// Corresponds to `full`
+    Full,
+}
+
 /// The arguments to pass to the Valgrind tool
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolArgs {
@@ -84,6 +96,8 @@ pub struct ToolArgs {
     pub trace_children: bool,
     /// If --verbose is set to true of false
     pub verbose: bool,
+    /// The --vgdb argument
+    pub vgdb: Vgdb,
     /// The xtree paths argument --xtree-leak-file
     pub xleak_path: Option<OsString>,
     /// The xtree paths argument --xtree-memory-file
@@ -142,6 +156,7 @@ impl ToolArgs {
             other: Vec::default(),
             trace_children: defaults::TRACE_CHILDREN,
             fair_sched: defaults::FAIR_SCHED,
+            vgdb: defaults::VGDB,
         };
 
         for args in raw_tool_args {
@@ -164,6 +179,9 @@ impl ToolArgs {
                          Gungraun",
                         tool.id()
                     ),
+                    Some((arg, _)) if is_ignored_argument(arg) => {
+                        warn!("Ignoring {} argument '{arg}'", tool.id());
+                    }
                     None if matches!(arg, "-v" | "--verbose") => tool_args.verbose = true,
                     None if is_ignored_argument(arg) => {
                         warn!("Ignoring {} argument '{arg}'", tool.id());
@@ -302,6 +320,7 @@ impl ToolArgs {
         vec.push(format!("--error-exitcode={}", &self.error_exitcode).into());
         vec.push(format!("--trace-children={}", &bool_to_yesno(self.trace_children)).into());
         vec.push(format!("--fair-sched={}", self.fair_sched).into());
+        vec.push(format!("--vgdb={}", self.vgdb).into());
         if self.verbose {
             vec.push("--verbose".into());
         }
@@ -347,6 +366,17 @@ impl ToolArgs {
     }
 }
 
+impl Display for Vgdb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string = match self {
+            Self::Yes => "yes",
+            Self::No => "no",
+            Self::Full => "full",
+        };
+        write!(f, "{string}")
+    }
+}
+
 /// Returns `true` if this is an ignored argument related to output or logfiles.
 pub fn is_ignored_outfile_argument(arg: &str) -> bool {
     matches!(
@@ -381,5 +411,6 @@ pub fn is_ignored_argument(arg: &str) -> bool {
             | "-q"
             | "--quiet"
             | "--tool"
+            | "--vgdb"
     )
 }

--- a/gungraun-runner/src/runner/tool/config.rs
+++ b/gungraun-runner/src/runner/tool/config.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use anyhow::{Result, anyhow};
 
 use super::super::common::Assistant;
-use super::args::ToolArgs;
+use super::args::{ToolArgs, ValgrindArgs};
 use super::parser::parser_factory;
 use super::path::ToolOutputPath;
 use super::regression::ToolRegressionConfig;
@@ -37,7 +37,7 @@ pub enum ToolFlamegraphConfig {
 #[derive(Debug, Clone)]
 pub struct ToolConfig {
     /// The arguments to pass to the Valgrind executable
-    pub args: ToolArgs,
+    pub args: ValgrindArgs,
     /// The [`EntryPoint`] of this tool
     pub entry_point: EntryPoint,
     /// The tool specific flamegraph configuration
@@ -76,7 +76,7 @@ impl ToolConfig {
     pub fn new(
         tool: ValgrindTool,
         is_enabled: bool,
-        args: ToolArgs,
+        args: ValgrindArgs,
         regression_config: ToolRegressionConfig,
         flamegraph_config: ToolFlamegraphConfig,
         entry_point: EntryPoint,
@@ -99,13 +99,17 @@ impl ToolConfig {
 impl ToolConfigBuilder {
     fn build(self) -> Result<ToolConfig> {
         let args = match self.kind {
-            ValgrindTool::Callgrind => {
-                callgrind::args::Args::try_from_raw_tool_args(&[&self.raw_tool_args])?.into()
-            }
-            ValgrindTool::Cachegrind => {
-                cachegrind::args::Args::try_from_raw_tool_args(&[&self.raw_tool_args])?.into()
-            }
-            _ => ToolArgs::try_from_raw_tool_args(self.kind, &[&self.raw_tool_args])?,
+            ValgrindTool::Callgrind => callgrind::args::CallgrindArgs::try_from_raw_tool_args(
+                self.kind,
+                &[&self.raw_tool_args],
+            )?
+            .into(),
+            ValgrindTool::Cachegrind => cachegrind::args::CachegrindArgs::try_from_raw_tool_args(
+                self.kind,
+                &[&self.raw_tool_args],
+            )?
+            .into(),
+            _ => ValgrindArgs::try_from_raw_tool_args(self.kind, &[&self.raw_tool_args])?,
         };
 
         Ok(ToolConfig::new(
@@ -324,8 +328,8 @@ impl ToolConfigs {
     ///
     /// `default_args` should only contain command-line arguments which are different for library
     /// and binary benchmarks on a per tool basis. Usually, default arguments are part of the tool
-    /// specific `Args` struct for example for callgrind [`callgrind::args::Args`] or cachegrind
-    /// [`cachegrind::args::Args`].
+    /// specific arguments struct for example for callgrind
+    /// [`callgrind::args::CallgrindArgs`] or cachegrind [`cachegrind::args::CachegrindArgs`].
     ///
     /// `valgrind_args` are from the in-benchmark configuration: `LibraryBenchmarkConfig` or
     /// `BinaryBenchmarkConfig`


### PR DESCRIPTION
- Set `--vgdb=no` by default to prevent errors for example during qemu system runs. Since this feature is currently not implemented in Gungraun, letting valgrind setting up vgdb is unnecessary.
- Refactor Valgrind argument parsing around a shared `ToolArgs` trait and a concrete `ValgrindArgs` type.

