### PR TITLE
Fix possible deadlock in threadpool when notify_one was missed

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -47,6 +47,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           key: ${{ matrix.toolchain }}
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-minimal-versions
@@ -62,6 +63,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@taplo
       - run: just check-fmt-all
@@ -74,5 +78,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@just
       - run: just lint

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@just
       - name: Check summary.json schema is up-to-date
         run: just schema-gen-diff
@@ -36,6 +39,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       # This is important for docs.rs which doesn't have the headers installed
       - name: Try build gungraun without valgrind headers
         run: cargo build --package gungraun --features client_requests_defs --release
@@ -94,12 +99,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          key: ${{ matrix.target }}
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@cross
       - uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
       - name: Install valgrind
         run: ./scripts/install_valgrind.sh "$VALGRIND_VERSION"
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,11 +30,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - uses: taiki-e/install-action@just
-      - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           key: ${{ matrix.toolchain }}
+      - uses: taiki-e/install-action@just
+      - uses: taiki-e/install-action@cargo-hack
       - name: Install valgrind
         run: ./scripts/install_valgrind.sh "$VALGRIND_VERSION"
         env:
@@ -64,11 +65,12 @@ jobs:
         if: matrix.toolchain != '1.85.1'
         run: |
           cargo update
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           key: ${{ matrix.toolchain }}
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@just
       - name: Build and install valgrind
         run: ./scripts/install_valgrind.sh "$VALGRIND_VERSION"
         env:
@@ -88,7 +90,6 @@ jobs:
           toolchain: "1.85.1"
           components: rust-src
       - uses: taiki-e/install-action@just
-      - uses: Swatinem/rust-cache@v2
       - name: Run ui tests
         run: |
           set -o pipefail
@@ -128,10 +129,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           key: ${{ matrix.filter }}_${{ matrix.partition }}
+      - uses: taiki-e/install-action@just
       - name: Install valgrind
         run: ./scripts/install_valgrind.sh "$VALGRIND_VERSION"
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,9 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
       - name: Build and install valgrind
         run: |
           brew tap LouisBrunner/valgrind
@@ -38,9 +40,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: "Prepare: Run cargo update"
         run: cargo update
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@just
-      - uses: Swatinem/rust-cache@v2
       - name: Build and install valgrind
         run: |
           brew tap LouisBrunner/valgrind

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - name: Publish gungraun-runner
         run: cargo publish -p gungraun-runner --token ${{ secrets.CRATES_GITHUB_TOKEN }}
       - name: Publish gungraun

--- a/.github/workflows/publish_gungraun_macros.yml
+++ b/.github/workflows/publish_gungraun_macros.yml
@@ -11,6 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - name: Publish gungraun-macros
         run: cargo publish -p gungraun-macros --token ${{ secrets.CRATES_GITHUB_TOKEN }}

--- a/.github/workflows/publish_valgrind_requests.yml
+++ b/.github/workflows/publish_valgrind_requests.yml
@@ -11,6 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - name: Publish valgrind-requests
         run: cargo publish -p valgrind-requests --token ${{ secrets.CRATES_GITHUB_TOKEN }}

--- a/.github/workflows/valgrind_requests.yml
+++ b/.github/workflows/valgrind_requests.yml
@@ -35,11 +35,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - uses: taiki-e/install-action@just
-      - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           key: ${{ matrix.toolchain }}
+      - uses: taiki-e/install-action@just
+      - uses: taiki-e/install-action@cargo-hack
       - name: Install valgrind
         if: matrix.os == 'ubuntu-latest'
         run: ./scripts/install_valgrind.sh "$VALGRIND_VERSION"
@@ -63,9 +64,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@just
-      - uses: Swatinem/rust-cache@v2
       - name: Install valgrind
         run: ./scripts/install_valgrind.sh "$VALGRIND_VERSION"
         env:
@@ -97,11 +100,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cross
-      - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           key: ${{ matrix.target }}
+      - uses: taiki-e/install-action@cross
+      - uses: taiki-e/install-action@just
       - name: Install valgrind
         run: ./scripts/install_valgrind.sh "$VALGRIND_VERSION"
         env:

--- a/gungraun-runner/src/runner/tasks.rs
+++ b/gungraun-runner/src/runner/tasks.rs
@@ -741,6 +741,7 @@ mod tests {
     #[case::size_19_jobs_20(19, 20)]
     #[case::equal_twenty(20, 20)]
     #[case::size_21_jobs_20(21, 20)]
+    #[timeout(Duration::from_secs(1))]
     fn test_thread_pool_execute_and_next(#[case] size: usize, #[case] jobs: usize) {
         let mut pool = ThreadPool::new(size).unwrap();
         for i in 0..jobs {
@@ -791,6 +792,107 @@ mod tests {
         pool.execute(|_| 42);
 
         assert_eq!(pool.next(), Some(42));
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    fn test_thread_pool_when_repeatedly_submitting_after_idle_then_jobs_complete() {
+        for _ in 0..1_000 {
+            let mut pool = ThreadPool::<usize>::new(1).unwrap();
+
+            sleep(Duration::from_micros(100));
+
+            pool.execute(|_| 1);
+
+            assert_eq!(pool.next(), Some(1));
+        }
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(2))]
+    fn test_thread_pool_when_submitting_after_idle_rounds_then_workers_wake() {
+        let mut pool = ThreadPool::<usize>::new(2).unwrap();
+
+        for i in 0..20 {
+            sleep(Duration::from_millis(5));
+
+            pool.execute(move |_| i);
+
+            assert_eq!(pool.next(), Some(i));
+        }
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    fn test_thread_pool_when_many_jobs_after_idle_then_all_complete() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        for _ in 0..100 {
+            let counter = Arc::new(AtomicUsize::new(0));
+            let mut pool = ThreadPool::<()>::new(8).unwrap();
+
+            sleep(Duration::from_micros(100));
+
+            for _ in 0..128 {
+                let counter = Arc::clone(&counter);
+                pool.execute(move |_| {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                });
+            }
+
+            for () in &mut pool {}
+
+            assert_eq!(counter.load(Ordering::Relaxed), 128);
+        }
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(2))]
+    fn test_thread_pool_when_job_is_running_then_idle_workers_wait() {
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (finish_sender, finish_receiver) = mpsc::channel();
+        let mut pool = ThreadPool::<usize>::new(4).unwrap();
+
+        pool.execute(move |_| {
+            started_sender.send(()).unwrap();
+            finish_receiver.recv().unwrap();
+            1
+        });
+
+        started_receiver.recv().unwrap();
+        sleep(Duration::from_millis(50));
+        finish_sender.send(()).unwrap();
+
+        assert_eq!(pool.next(), Some(1));
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(2))]
+    fn test_thread_pool_when_shutdown_with_blocked_workers_then_queued_jobs_complete() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let (finish_sender, finish_receiver) = mpsc::channel();
+        let finish_receiver = Arc::new(Mutex::new(finish_receiver));
+        let mut pool = ThreadPool::<()>::new(2).unwrap();
+
+        for _ in 0..8 {
+            let counter = Arc::clone(&counter);
+            let finish_receiver = Arc::clone(&finish_receiver);
+
+            pool.execute(move |_| {
+                finish_receiver.lock().recv().unwrap();
+                counter.fetch_add(1, Ordering::Relaxed);
+            });
+        }
+
+        for _ in 0..8 {
+            finish_sender.send(()).unwrap();
+        }
+
+        pool.shutdown();
+
+        assert_eq!(counter.load(Ordering::Relaxed), 8);
     }
 
     #[rstest]

--- a/gungraun-runner/src/runner/tasks.rs
+++ b/gungraun-runner/src/runner/tasks.rs
@@ -193,6 +193,8 @@ pub struct ThreadPool<T: Send + 'static> {
 struct ThreadPoolState {
     /// Number of jobs that have been submitted but have not finished sending their result.
     pending_jobs: usize,
+    /// Number of jobs submitted to the queue that workers have not started yet.
+    queued_jobs: usize,
     /// Whether workers may exit once pending work is done.
     shutdown: bool,
 }
@@ -555,8 +557,15 @@ impl<T: Send + 'static> ThreadPool<T> {
                     });
 
                     if let Some((id, job)) = job {
-                        let force_shutdown = Arc::clone(&force_shutdown);
+                        {
+                            let (lock, _) = &*state;
+                            let mut thread_state = lock.lock();
 
+                            debug_assert!(thread_state.queued_jobs > 0);
+                            thread_state.queued_jobs -= 1;
+                        }
+
+                        let force_shutdown = Arc::clone(&force_shutdown);
                         let result = job(force_shutdown);
 
                         let send_result = result_sender
@@ -567,7 +576,6 @@ impl<T: Send + 'static> ThreadPool<T> {
                         let mut thread_state = lock.lock();
 
                         debug_assert!(thread_state.pending_jobs > 0);
-
                         // Decrement and notify before propagating a send error so shutdown can
                         // still observe that this job finished.
                         thread_state.pending_jobs -= 1;
@@ -579,6 +587,9 @@ impl<T: Send + 'static> ThreadPool<T> {
                         let mut thread_state = lock.lock();
                         if thread_state.shutdown && thread_state.pending_jobs == 0 {
                             break;
+                        }
+                        if thread_state.queued_jobs > 0 {
+                            continue;
                         }
 
                         condvar.wait(&mut thread_state);
@@ -627,6 +638,7 @@ impl<T: Send + 'static> ThreadPool<T> {
         );
 
         state.pending_jobs += 1;
+        state.queued_jobs += 1;
 
         let num_jobs = self.total_jobs.get_or_insert(0);
         self.job_queue.push((*num_jobs, Box::new(job)));


### PR DESCRIPTION
This PR fixes a possible deadlock introduced by replacing worker busy-spinning with `Condvar` parking.

The deadlock occurred when a worker checked the queues, found no job, then missed the only `notify_one()` from `execute()` and went to sleep while a job was already queued. This could leave the job unprocessed forever, causing `ThreadPool::next()` to block indefinitely.

The fix adds explicit queued-work tracking:

- `pending_jobs`: submitted jobs not yet completed
- `queued_jobs`: submitted jobs not yet started
- `shutdown`: graceful shutdown state

Workers now only wait on the `Condvar` when `queued_jobs == 0`. If work has been queued but not started, they retry stealing instead of sleeping. This preserves the no-busy-spin behavior for idle workers while preventing missed-notification deadlocks.

Added more tests, especially stress tests

AI Tools were used to create parts of the documentation, this pr message and tests