### PR TITLE
feat(baseline): Allow `--save-baseline` and `--baseline` to both be specified

### DIFF
--- a/benchmark-tests/benches/test_bin_bench/nocapture/expected_stdout.2d
+++ b/benchmark-tests/benches/test_bin_bench/nocapture/expected_stdout.2d
@@ -1,0 +1,70 @@
+1 2
+test_bin_bench_nocapture::simple::bench_echo both_inherit:(Stdio :: Inherit, Stdio :: Inherit) -> target/rel...
+- end of stdout/stderr
+  Baselines:                            foo|bar
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_bin_bench_nocapture::simple::bench_echo both_null:(Stdio :: Null, Stdio :: Null) -> target/release/e...
+- end of stdout/stderr
+  Baselines:                            foo|bar
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_bin_bench_nocapture::simple::bench_echo both_piped:(Stdio :: Pipe, Stdio :: Pipe) -> target/release/e...
+- end of stdout/stderr
+  Baselines:                            foo|bar
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_bin_bench_nocapture::simple::bench_echo both_file_when_exists:(Stdio :: File("file.stdout".into()), Stdio :: Fil...
+create file for stdout: file.stdout
+create file for stderr: file.stderr
+- end of stdout/stderr
+  Baselines:                            foo|bar
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_bin_bench_nocapture::simple::bench_echo both_file_when_not_exists:(Stdio :: File("file.stdout".into()), Stdio :: Fil...
+- end of stdout/stderr
+  Baselines:                            foo|bar
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+test_bin_bench_nocapture::simple::bench_pipe :() -> target/release/pipe
+STDIN was:
+Something- end of stdout/stderr
+  ======= CALLGRIND ====================================================================
+  Baselines:                            foo|bar
+  Instructions:                            |                     (No change)
+  L1 Hits:                                 |                     (         )
+  LL Hits:                                 |                     (         )
+  RAM Hits:                                |                     (         )
+  Total read+write:                        |                     (No change)
+  Estimated Cycles:                        |                     (         )
+  ======= DHAT =========================================================================
+  Total bytes:                             |                     (No change)
+  Total blocks:                            |                     (No change)
+  At t-gmax bytes:                         |                     (         )
+  At t-gmax blocks:                        |                     (         )
+  At t-end bytes:                          |                     (No change)
+  At t-end blocks:                         |                     (No change)
+  Reads bytes:                             |                     (No change)
+  Writes bytes:                            |                     (No change)
+
+Gungraun result: Ok. 6 without regressions; 0 regressed; 0 filtered; 6 benchmarks finished in <__SECONDS__>s

--- a/benchmark-tests/benches/test_bin_bench/nocapture/test_bin_bench_nocapture.conf.yml
+++ b/benchmark-tests/benches/test_bin_bench/nocapture/test_bin_bench_nocapture.conf.yml
@@ -2,10 +2,13 @@
 #
 # Description:
 #   Tests the `--nocapture` flag combined with various `Stdio` configurations
-#   for stdout and stderr handling in binary benchmarks.
+#   for stdout and stderr handling in binary benchmarks, including baseline
+#   save/load and combined save/compare baseline modes.
 #
 # Test Steps:
 #   1. Run benchmark with `--nocapture` testing different Stdio configurations
+#   2. Run `--nocapture` together with named save, load, and combined
+#      save/compare baseline modes.
 #
 # Test Inputs:
 #   - `Stdio::Inherit` - inherit from parent process
@@ -15,6 +18,8 @@
 #   - Sandbox mode enabled/disabled for file creation tests
 #   - `DHAT` tool for memory profiling
 #   - `Stdin::Setup(Pipe::Stdout)` for piped input
+#   - `--save-baseline`, `--load-baseline`, and combined
+#     `--save-baseline`/`--baseline` baseline modes
 #
 # Expected Outcomes:
 #   - Stdio configurations work as specified
@@ -22,6 +27,8 @@
 #   - Files created when using `Stdio::File` (both pre-existing and new)
 #   - Output captured appropriately based on Stdio config
 #   - Setup output pipes to command stdin when configured
+#   - Baseline labels are printed correctly when saving one baseline while
+#     comparing against another.
 
 groups:
   - runs:
@@ -38,3 +45,6 @@ groups:
       - args: ["--nocapture", "--load-baseline=foo", "--baseline=bar"]
         expected:
           stdout: expected_stdout.2c
+      - args: ["--nocapture", "--save-baseline=foo", "--baseline=bar"]
+        expected:
+          stdout: expected_stdout.2d

--- a/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.3f.yml
+++ b/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.3f.yml
@@ -1,0 +1,119 @@
+data:
+  - group: recursive
+    function: recursive_function
+    id: fibonacci
+    expected:
+      files:
+        - callgrind.recursive_function.fibonacci.log
+        - callgrind.recursive_function.fibonacci.log.base@bar
+        - callgrind.recursive_function.fibonacci.log.base@foo
+        - callgrind.recursive_function.fibonacci.out
+        - callgrind.recursive_function.fibonacci.out.base@bar
+        - callgrind.recursive_function.fibonacci.out.base@foo
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@bar.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@foo.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: all_kinds
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.all_kinds.log
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.out
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@foo.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.svg
+        - summary.json
+  - group: benches
+    function: without_bench_attribute
+    expected:
+      files:
+        - callgrind.without_bench_attribute.log
+        - callgrind.without_bench_attribute.log.base@bar
+        - callgrind.without_bench_attribute.log.base@foo
+        - callgrind.without_bench_attribute.out
+        - callgrind.without_bench_attribute.out.base@bar
+        - callgrind.without_bench_attribute.out.base@foo
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@bar.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@foo.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.svg
+        - summary.json
+  - group: benches
+    function: function_with_many_stacks
+    expected:
+      files:
+        - callgrind.function_with_many_stacks.log
+        - callgrind.function_with_many_stacks.log.base@bar
+        - callgrind.function_with_many_stacks.log.base@foo
+        - callgrind.function_with_many_stacks.out
+        - callgrind.function_with_many_stacks.out.base@bar
+        - callgrind.function_with_many_stacks.out.base@foo
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@bar.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@foo.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: differential_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.differential_kind.log
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.out
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: regular_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.regular_kind.log
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.out
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@foo.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: none_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.none_kind.log
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.none_kind.out
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@foo
+        - summary.json
+  - group: benches
+    function: main_level_flamegraph_config
+    id: worst_case
+    expected:
+      files:
+        - callgrind.main_level_flamegraph_config.worst_case.log
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.out
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@bar.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@foo.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.svg
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4a.yml
+++ b/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4a.yml
@@ -1,0 +1,113 @@
+data:
+  - group: recursive
+    function: recursive_function
+    id: fibonacci
+    expected:
+      files:
+        - callgrind.recursive_function.fibonacci.log.base@bar
+        - callgrind.recursive_function.fibonacci.log.base@baz
+        - callgrind.recursive_function.fibonacci.log.base@foo
+        - callgrind.recursive_function.fibonacci.out.base@bar
+        - callgrind.recursive_function.fibonacci.out.base@baz
+        - callgrind.recursive_function.fibonacci.out.base@foo
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@bar.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@baz.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: all_kinds
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: without_bench_attribute
+    expected:
+      files:
+        - callgrind.without_bench_attribute.log.base@bar
+        - callgrind.without_bench_attribute.log.base@baz
+        - callgrind.without_bench_attribute.log.base@foo
+        - callgrind.without_bench_attribute.out.base@bar
+        - callgrind.without_bench_attribute.out.base@baz
+        - callgrind.without_bench_attribute.out.base@foo
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@bar.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@baz.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: function_with_many_stacks
+    expected:
+      files:
+        - callgrind.function_with_many_stacks.log.base@bar
+        - callgrind.function_with_many_stacks.log.base@baz
+        - callgrind.function_with_many_stacks.log.base@foo
+        - callgrind.function_with_many_stacks.out.base@bar
+        - callgrind.function_with_many_stacks.out.base@baz
+        - callgrind.function_with_many_stacks.out.base@foo
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@bar.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@baz.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: differential_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@foo
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: regular_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: none_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@foo
+        - summary.json
+  - group: benches
+    function: main_level_flamegraph_config
+    id: worst_case
+    expected:
+      files:
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@bar.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@baz.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@foo.svg
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4b.yml
+++ b/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4b.yml
@@ -1,0 +1,119 @@
+data:
+  - group: recursive
+    function: recursive_function
+    id: fibonacci
+    expected:
+      files:
+        - callgrind.recursive_function.fibonacci.log.base@bar
+        - callgrind.recursive_function.fibonacci.log.base@baz
+        - callgrind.recursive_function.fibonacci.log.base@foo
+        - callgrind.recursive_function.fibonacci.out.base@bar
+        - callgrind.recursive_function.fibonacci.out.base@baz
+        - callgrind.recursive_function.fibonacci.out.base@foo
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@bar.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@baz.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: all_kinds
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: without_bench_attribute
+    expected:
+      files:
+        - callgrind.without_bench_attribute.log.base@bar
+        - callgrind.without_bench_attribute.log.base@baz
+        - callgrind.without_bench_attribute.log.base@foo
+        - callgrind.without_bench_attribute.out.base@bar
+        - callgrind.without_bench_attribute.out.base@baz
+        - callgrind.without_bench_attribute.out.base@foo
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@bar.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@baz.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: function_with_many_stacks
+    expected:
+      files:
+        - callgrind.function_with_many_stacks.log.base@bar
+        - callgrind.function_with_many_stacks.log.base@baz
+        - callgrind.function_with_many_stacks.log.base@foo
+        - callgrind.function_with_many_stacks.out.base@bar
+        - callgrind.function_with_many_stacks.out.base@baz
+        - callgrind.function_with_many_stacks.out.base@foo
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@bar.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@baz.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: differential_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: regular_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: none_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@foo
+        - summary.json
+  - group: benches
+    function: main_level_flamegraph_config
+    id: worst_case
+    expected:
+      files:
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@bar.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@baz.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@foo.diff.base@bar.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@foo.svg
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4c.yml
+++ b/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4c.yml
@@ -1,0 +1,119 @@
+data:
+  - group: recursive
+    function: recursive_function
+    id: fibonacci
+    expected:
+      files:
+        - callgrind.recursive_function.fibonacci.log.base@bar
+        - callgrind.recursive_function.fibonacci.log.base@baz
+        - callgrind.recursive_function.fibonacci.log.base@foo
+        - callgrind.recursive_function.fibonacci.out.base@bar
+        - callgrind.recursive_function.fibonacci.out.base@baz
+        - callgrind.recursive_function.fibonacci.out.base@foo
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@bar.diff.base@foo.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@bar.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@baz.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: all_kinds
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@bar.diff.base@foo.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: without_bench_attribute
+    expected:
+      files:
+        - callgrind.without_bench_attribute.log.base@bar
+        - callgrind.without_bench_attribute.log.base@baz
+        - callgrind.without_bench_attribute.log.base@foo
+        - callgrind.without_bench_attribute.out.base@bar
+        - callgrind.without_bench_attribute.out.base@baz
+        - callgrind.without_bench_attribute.out.base@foo
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@bar.diff.base@foo.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@bar.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@baz.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: function_with_many_stacks
+    expected:
+      files:
+        - callgrind.function_with_many_stacks.log.base@bar
+        - callgrind.function_with_many_stacks.log.base@baz
+        - callgrind.function_with_many_stacks.log.base@foo
+        - callgrind.function_with_many_stacks.out.base@bar
+        - callgrind.function_with_many_stacks.out.base@baz
+        - callgrind.function_with_many_stacks.out.base@foo
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@bar.diff.base@foo.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@bar.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@baz.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: differential_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.total.Ir.flamegraph.base@bar.diff.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: regular_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: none_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@foo
+        - summary.json
+  - group: benches
+    function: main_level_flamegraph_config
+    id: worst_case
+    expected:
+      files:
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@bar.diff.base@foo.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@bar.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@baz.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@foo.svg
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4d.yml
+++ b/benchmark-tests/benches/test_lib_bench/flamegraph/expected_files.4d.yml
@@ -1,0 +1,119 @@
+data:
+  - group: recursive
+    function: recursive_function
+    id: fibonacci
+    expected:
+      files:
+        - callgrind.recursive_function.fibonacci.log.base@bar
+        - callgrind.recursive_function.fibonacci.log.base@baz
+        - callgrind.recursive_function.fibonacci.log.base@foo
+        - callgrind.recursive_function.fibonacci.out.base@bar
+        - callgrind.recursive_function.fibonacci.out.base@baz
+        - callgrind.recursive_function.fibonacci.out.base@foo
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@bar.diff.base@baz.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@bar.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@baz.svg
+        - callgrind.recursive_function.fibonacci.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: all_kinds
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.log.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@bar
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@baz
+        - callgrind.bench_level_flamegraphs.all_kinds.out.base@foo
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@bar.diff.base@baz.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.all_kinds.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: without_bench_attribute
+    expected:
+      files:
+        - callgrind.without_bench_attribute.log.base@bar
+        - callgrind.without_bench_attribute.log.base@baz
+        - callgrind.without_bench_attribute.log.base@foo
+        - callgrind.without_bench_attribute.out.base@bar
+        - callgrind.without_bench_attribute.out.base@baz
+        - callgrind.without_bench_attribute.out.base@foo
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@bar.diff.base@baz.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@bar.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@baz.svg
+        - callgrind.without_bench_attribute.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: function_with_many_stacks
+    expected:
+      files:
+        - callgrind.function_with_many_stacks.log.base@bar
+        - callgrind.function_with_many_stacks.log.base@baz
+        - callgrind.function_with_many_stacks.log.base@foo
+        - callgrind.function_with_many_stacks.out.base@bar
+        - callgrind.function_with_many_stacks.out.base@baz
+        - callgrind.function_with_many_stacks.out.base@foo
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@bar.diff.base@baz.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@bar.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@baz.svg
+        - callgrind.function_with_many_stacks.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: differential_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.differential_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.differential_kind.total.Ir.flamegraph.base@bar.diff.base@baz.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: regular_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.regular_kind.out.base@foo
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@bar.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@baz.svg
+        - callgrind.bench_level_flamegraphs.regular_kind.total.Ir.flamegraph.base@foo.svg
+        - summary.json
+  - group: benches
+    function: bench_level_flamegraphs
+    id: none_kind
+    expected:
+      files:
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.log.base@foo
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@bar
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@baz
+        - callgrind.bench_level_flamegraphs.none_kind.out.base@foo
+        - summary.json
+  - group: benches
+    function: main_level_flamegraph_config
+    id: worst_case
+    expected:
+      files:
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.log.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@bar
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@baz
+        - callgrind.main_level_flamegraph_config.worst_case.out.base@foo
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@bar.diff.base@baz.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@bar.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@baz.svg
+        - callgrind.main_level_flamegraph_config.worst_case.total.Ir.flamegraph.base@foo.svg
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/flamegraph/test_lib_bench_flamegraph.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/flamegraph/test_lib_bench_flamegraph.conf.yml
@@ -6,17 +6,16 @@
 #   level.
 #
 # Test Steps:
-#   1. Run benchmarks three times to create a baseline, then again to compare
-#      against the baseline and a third time to assure there are no differences
-#      between the second and third run.
-#   2. Run benchmarks with --save-baseline the first time to create the named
-#      baseline. Then, a second time to assure there are no differences. Then run
-#      with --baseline to compare a normal run with the named baseline. Then run
-#      a last time with --save-baseline
-#   3. Create two different name baselines in two runs. The run with
-#      --load-baseline and --baseline to compare these baselines. Run again with
-#      --baseline to compare the named baseline with the normal baseline.
-#      Afterwards, run a last time with --save-baseline
+#   1. Run benchmarks three times to create a baseline, compare against it, and
+#      verify repeated runs keep the same flamegraph file set.
+#   2. Run with --save-baseline to create a named baseline, repeat it, compare a
+#      normal run with --baseline, then save the named baseline again to verify
+#      differential flamegraph cleanup.
+#   3. Create two named baselines, compare them with --load-baseline and
+#      --baseline, compare a normal run with a named baseline, then save again.
+#   4. Create two named baselines, run --save-baseline together with --baseline
+#      to save current data under one baseline while comparing against the other,
+#      repeat the same direction, then reverse the baseline direction.
 #
 # Test Inputs:
 #   - FlamegraphKind::Regular: generates regular flamegraph only
@@ -24,7 +23,8 @@
 #   - FlamegraphKind::All: generates both regular and differential
 #   - FlamegraphKind::None: generates no flamegraphs
 #   - Configuration at multiple levels (bench, group, main)
-#   - --baseline, --save-baseline and --load-baseline for comparison flamegraphs
+#   - --baseline, --save-baseline, --load-baseline, and combined
+#     --save-baseline/--baseline for comparison flamegraphs
 #   - Functions with recursive calls and deep stacks
 #
 # Expected Outcomes:
@@ -32,7 +32,15 @@
 #   - Configuration inheritance from main > group > bench levels works correctly
 #   - No flamegraphs generated when kind is None
 #   - Differential flamegraphs are generated.
-#   - Differential flamegraphs are cleanup up correctly between runs.
+#   - Differential flamegraphs are cleaned up correctly between runs.
+#   - Combined --save-baseline/--baseline writes regular flamegraphs for the
+#     saved baseline and differential flamegraphs against the comparison baseline.
+#   - Repeated combined runs clean up stale differential flamegraphs for the same
+#     saved/comparison baseline pair.
+#   - Reusing one saved baseline with a different comparison baseline removes
+#     stale differential flamegraphs for the saved baseline only, so
+#     base@bar.diff.base@foo is replaced by base@bar.diff.base@baz without
+#     deleting unrelated base@foo diff files.
 
 groups:
   - runs:
@@ -56,7 +64,7 @@ groups:
         expected:
           files: expected_files.2c.yml
       # The differential flamegraphs created in the previous run between the
-      # normal baseline and the named baseline should be cleanup up in this run.
+      # normal baseline and the named baseline should be cleaned up in this run.
       - args: ["--save-baseline=foo"]
         expected:
           files: expected_files.2d.yml
@@ -79,3 +87,31 @@ groups:
       - args: ["--save-baseline=foo"]
         expected:
           files: expected_files.3e.yml
+      - args: ["--save-baseline=foo", "--baseline=bar"]
+        expected:
+          files: expected_files.3f.yml
+  - runs:
+      - args: ["--save-baseline=foo"]
+        expected:
+          files: expected_files.3a.yml
+      - args: ["--save-baseline=bar"]
+        expected:
+          files: expected_files.3b.yml
+      - args: ["--save-baseline=baz"]
+        expected:
+          files: expected_files.4a.yml
+      - args: ["--save-baseline=foo", "--baseline=bar"]
+        expected:
+          files: expected_files.4b.yml
+      - args: ["--save-baseline=foo", "--baseline=bar"]
+        expected:
+          files: expected_files.4b.yml
+      # This verifies stale diff cleanup when a saved baseline is reused with a
+      # different comparison baseline: base@bar.diff.base@foo must be replaced
+      # by base@bar.diff.base@baz, while unrelated base@foo diffs remain.
+      - args: ["--save-baseline=bar", "--baseline=foo"]
+        expected:
+          files: expected_files.4c.yml
+      - args: ["--save-baseline=bar", "--baseline=baz"]
+        expected:
+          files: expected_files.4d.yml

--- a/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3a.>=1.89.yml
+++ b/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3a.>=1.89.yml
@@ -1,0 +1,81 @@
+data:
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: massif
+    expected:
+      files:
+        - massif.bench_with_xtree_no_leak.massif.log.base@foo
+        - massif.bench_with_xtree_no_leak.massif.out.base@foo
+        - massif.bench_with_xtree_no_leak.massif.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xleak.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.xleak.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xleak.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: helgrind
+    expected:
+      files:
+        - helgrind.bench_with_xtree_no_leak.helgrind.log.base@foo
+        - helgrind.bench_with_xtree_no_leak.helgrind.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xleak.xleak.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_in_subprocess
+    id: memcheck_multi_process
+    expected:
+      globs:
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.log.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xleak.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xtree.base@foo
+          count: 2
+      files:
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3a.yml
+++ b/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3a.yml
@@ -1,0 +1,79 @@
+data:
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: massif
+    expected:
+      files:
+        - massif.bench_with_xtree_no_leak.massif.log.base@foo
+        - massif.bench_with_xtree_no_leak.massif.out.base@foo
+        - massif.bench_with_xtree_no_leak.massif.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xleak.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.log.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: helgrind
+    expected:
+      files:
+        - helgrind.bench_with_xtree_no_leak.helgrind.log.base@foo
+        - helgrind.bench_with_xtree_no_leak.helgrind.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xleak.xleak.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_in_subprocess
+    id: memcheck_multi_process
+    expected:
+      globs:
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.log.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xleak.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xtree.base@foo
+          count: 2
+      files:
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3b.>=1.89.yml
+++ b/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3b.>=1.89.yml
@@ -1,0 +1,106 @@
+data:
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: massif
+    expected:
+      files:
+        - massif.bench_with_xtree_no_leak.massif.log.base@bar
+        - massif.bench_with_xtree_no_leak.massif.log.base@foo
+        - massif.bench_with_xtree_no_leak.massif.out.base@bar
+        - massif.bench_with_xtree_no_leak.massif.out.base@foo
+        - massif.bench_with_xtree_no_leak.massif.xtree.base@bar
+        - massif.bench_with_xtree_no_leak.massif.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree.log.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree.xtree.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.log.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xleak.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xleak.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xtree.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.log.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.xtree.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.log.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.xleak.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.xleak.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.log.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xleak.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xleak.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xtree.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: helgrind
+    expected:
+      files:
+        - helgrind.bench_with_xtree_no_leak.helgrind.log.base@bar
+        - helgrind.bench_with_xtree_no_leak.helgrind.log.base@foo
+        - helgrind.bench_with_xtree_no_leak.helgrind.xtree.base@bar
+        - helgrind.bench_with_xtree_no_leak.helgrind.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xleak.log.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xleak.xleak.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xleak.xleak.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_in_subprocess
+    id: memcheck_multi_process
+    expected:
+      globs:
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.log.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xleak.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xtree.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.log.base@bar
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xleak.base@bar
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xtree.base@bar
+          count: 2
+      files:
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3b.yml
+++ b/benchmark-tests/benches/test_lib_bench/xtree/expected_files.3b.yml
@@ -1,0 +1,102 @@
+data:
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: massif
+    expected:
+      files:
+        - massif.bench_with_xtree_no_leak.massif.log.base@bar
+        - massif.bench_with_xtree_no_leak.massif.log.base@foo
+        - massif.bench_with_xtree_no_leak.massif.out.base@bar
+        - massif.bench_with_xtree_no_leak.massif.out.base@foo
+        - massif.bench_with_xtree_no_leak.massif.xtree.base@bar
+        - massif.bench_with_xtree_no_leak.massif.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree.log.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree.xtree.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.log.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xleak.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xleak.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xtree.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.log.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.xtree.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.log.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xleak.log.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: memcheck_xtree_and_xleak
+    expected:
+      files:
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.log.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.log.base@foo
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xtree.base@bar
+        - memcheck.bench_with_xtree_no_leak.memcheck_xtree_and_xleak.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_no_leak
+    id: helgrind
+    expected:
+      files:
+        - helgrind.bench_with_xtree_no_leak.helgrind.log.base@bar
+        - helgrind.bench_with_xtree_no_leak.helgrind.log.base@foo
+        - helgrind.bench_with_xtree_no_leak.helgrind.xtree.base@bar
+        - helgrind.bench_with_xtree_no_leak.helgrind.xtree.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_memcheck_when_leak
+    id: xleak
+    expected:
+      files:
+        - memcheck.bench_with_memcheck_when_leak.xleak.log.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xleak.log.base@foo
+        - memcheck.bench_with_memcheck_when_leak.xleak.xleak.base@bar
+        - memcheck.bench_with_memcheck_when_leak.xleak.xleak.base@foo
+        - summary.json
+  - group: my_group
+    function: bench_with_xtree_in_subprocess
+    id: memcheck_multi_process
+    expected:
+      globs:
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.log.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xleak.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xtree.base@foo
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.log.base@bar
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xleak.base@bar
+          count: 2
+        - pattern: memcheck.bench_with_xtree_in_subprocess.memcheck_multi_process.*.xtree.base@bar
+          count: 2
+      files:
+        - summary.json

--- a/benchmark-tests/benches/test_lib_bench/xtree/test_lib_bench_xtree.conf.yml
+++ b/benchmark-tests/benches/test_lib_bench/xtree/test_lib_bench_xtree.conf.yml
@@ -9,6 +9,9 @@
 #   1. Run with various xtree configurations (first group: without memory leak)
 #   2. Run with xtree options and memory leak to test leak detection and report
 #   3. Run with xtree in subprocess to test multi-process handling
+#   4. Create two named baselines and run --save-baseline together with
+#      --baseline in both directions to verify xtree/xleak files are preserved
+#      for both saved baselines.
 #
 # Test Inputs:
 #   - `xtree-memory=full` for memory profiling
@@ -16,11 +19,14 @@
 #   - Combined xtree-memory and xtree-leak options
 #   - Benchmarks with and without intentional memory leaks
 #   - Subprocess benchmarks that leak memory
+#   - Combined --save-baseline/--baseline baseline mode
 #
 # Expected Outcomes:
 #   - xtree/xleak output files are created correctly
 #   - Memory leaks are detected and reported
 #   - Baseline save/load works with xtree output
+#   - Combined --save-baseline/--baseline works with xtree/xleak output files
+#     without removing the comparison baseline files.
 #
 # Test Environment:
 #   - Excluded on nightly Rust due to memcheck reporting issues (Rust issue
@@ -64,6 +70,23 @@ groups:
       - args: ["--save-baseline=other"]
         expected:
           files: expected_files.2d.>=1.89.yml
+  - rust_version: ">=1.89"
+    runs:
+      - args: ["--save-baseline=foo"]
+        expected:
+          files: expected_files.3a.>=1.89.yml
+      - args: ["--save-baseline=bar"]
+        expected:
+          files: expected_files.3b.>=1.89.yml
+      - args: ["--save-baseline=foo", "--baseline=bar"]
+        expected:
+          files: expected_files.3b.>=1.89.yml
+      - args: ["--save-baseline=foo", "--baseline=bar"]
+        expected:
+          files: expected_files.3b.>=1.89.yml
+      - args: ["--save-baseline=bar", "--baseline=foo"]
+        expected:
+          files: expected_files.3b.>=1.89.yml
   - rust_version: "<1.89"
     runs:
       - args: []
@@ -98,3 +121,20 @@ groups:
       - args: ["--save-baseline=other"]
         expected:
           files: expected_files.2d.yml
+  - rust_version: "<1.89"
+    runs:
+      - args: ["--save-baseline=foo"]
+        expected:
+          files: expected_files.3a.yml
+      - args: ["--save-baseline=bar"]
+        expected:
+          files: expected_files.3b.yml
+      - args: ["--save-baseline=foo", "--baseline=bar"]
+        expected:
+          files: expected_files.3b.yml
+      - args: ["--save-baseline=foo", "--baseline=bar"]
+        expected:
+          files: expected_files.3b.yml
+      - args: ["--save-baseline=bar", "--baseline=foo"]
+        expected:
+          files: expected_files.3b.yml

--- a/docs/src/cli_and_env/baselines.md
+++ b/docs/src/cli_and_env/baselines.md
@@ -13,7 +13,9 @@ baselines. If you are familiar with
 the following command line arguments should also be very familiar to you:
 
 - `--save-baseline=NAME` (env: `GUNGRAUN_SAVE_BASELINE`): Compare against the
-  `NAME` baseline if present and then overwrite it.
+  `NAME` baseline if present and then overwrite it. When combined with
+  `--baseline=BASELINE`, compare against `BASELINE` and save the current results
+  as `NAME`.
 - `--baseline=NAME` (env: `GUNGRAUN_BASELINE`): Compare against the `NAME`
   baseline without overwriting it
 - `--load-baseline=NAME` (env: `GUNGRAUN_LOAD_BASELINE`): Load the `NAME`
@@ -31,6 +33,16 @@ git checkout feature
 # ... HACK ... HACK
 cargo bench --bench <benchmark> -- --baseline=main
 ```
+
+You can also compare against one baseline and save the current results under a
+different baseline name:
+
+```shell
+cargo bench --bench <benchmark> -- --baseline=main --save-baseline=pr_1234
+```
+
+This prints `Baselines: pr_1234|main`, reads the old/reference data from `main`,
+and saves the current/new data as `pr_1234`.
 
 Sticking to the above execution sequence,
 

--- a/gungraun-runner/src/runner/args.rs
+++ b/gungraun-runner/src/runner/args.rs
@@ -30,7 +30,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use clap::builder::{BoolishValueParser, PathBufValueParser, TypedValueParser};
-use clap::{ArgAction, Parser};
+use clap::{ArgAction, CommandFactory, Parser};
 use indexmap::{IndexMap, IndexSet, indexset};
 use simplematch::{DoWild, Options};
 use strum::IntoEnumIterator;
@@ -1070,22 +1070,24 @@ pub struct CommandLineArgs {
     /// Save benchmark results as a named baseline for future comparisons
     ///
     /// If a baseline with this name already exists, Gungraun first compares against it before
-    /// overwriting with the new results.
+    /// overwriting with the new results. If this option is used together with `--baseline`,
+    /// Gungraun compares against the baseline selected by `--baseline` and saves the new results
+    /// with the name selected by `--save-baseline`.
     ///
     /// This option is useful for creating reference measurements (like from the main branch or a
     /// release tag) that you can later compare against using `--baseline`.
     ///
-    /// This option conflicts with `--baseline` and `--load-baseline`. Use `--baseline` instead if
-    /// you want to compare without overwriting the reference baseline. See `--baseline` to compare
-    /// against a saved baseline without modifying it and `--load-baseline` to compare existing
-    /// baselines without running benchmarks.
+    /// This option conflicts with `--load-baseline`. See `--baseline` to compare against a saved
+    /// baseline without modifying it and `--load-baseline` to compare existing baselines without
+    /// running benchmarks.
     ///
     /// Examples:
     ///   * `--save-baseline` (uses the default baseline name "default")
     ///   * `--save-baseline=main` (saves as baseline "main")
     ///   * `--save-baseline=v1.0` (saves as baseline "v1.0")
+    ///   * `--save-baseline=pr_1234 --baseline=main` (compares against "main", saves as `pr_1234`)
     #[arg(
-        conflicts_with_all = &["baseline", "LOAD_BASELINE"],
+        conflicts_with = "LOAD_BASELINE",
         default_missing_value = "default",
         display_order = 200,
         env = "GUNGRAUN_SAVE_BASELINE",
@@ -1476,6 +1478,43 @@ pub struct CommandLineArgs {
         verbatim_doc_comment
     )]
     pub workspace_root: Option<PathBuf>,
+}
+
+impl CommandLineArgs {
+    /// Parses command-line arguments and exits on parsing or validation errors.
+    pub fn parse_validated_from<I, T>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        Self::try_parse_validated_from(iter).unwrap_or_else(|error| error.exit())
+    }
+
+    /// Parses command-line arguments and validates relationships between parsed options.
+    pub fn try_parse_validated_from<I, T>(iter: I) -> clap::error::Result<Self>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        Self::try_parse_from(iter).and_then(|args| args.validate().map(|()| args))
+    }
+
+    fn validate(&self) -> clap::error::Result<()> {
+        if let (Some(save_baseline), Some(baseline)) = (&self.save_baseline, &self.baseline) {
+            if save_baseline == baseline {
+                let mut cmd = Self::command();
+                return Err(cmd.error(
+                    clap::error::ErrorKind::ValueValidation,
+                    format!(
+                        "--save-baseline and --baseline cannot use the same baseline name; use \
+                         only --save-baseline={save_baseline} instead"
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 /// A wrapper type for raw command-line arguments
@@ -1958,6 +1997,44 @@ mod tests {
     #[test]
     fn test_parse_tool_args_when_empty_then_error() {
         parse_tool_args("").unwrap_err();
+    }
+
+    #[test]
+    fn test_save_baseline_with_baseline_is_allowed() {
+        let result = CommandLineArgs::try_parse_validated_from([
+            "--save-baseline=pr_1234",
+            "--baseline=main_2025_01_02",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            result.save_baseline,
+            Some(BaselineName("pr_1234".to_owned()))
+        );
+        assert_eq!(
+            result.baseline,
+            Some(BaselineName("main_2025_01_02".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_save_baseline_with_same_baseline_is_rejected() {
+        let error =
+            CommandLineArgs::try_parse_validated_from(["--save-baseline=main", "--baseline=main"])
+                .unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(
+            error
+                .to_string()
+                .contains("use only --save-baseline=main instead")
+        );
+    }
+
+    #[test]
+    fn test_save_baseline_with_load_baseline_is_rejected() {
+        CommandLineArgs::try_parse_from(["--save-baseline=pr_1234", "--load-baseline=main"])
+            .unwrap_err();
     }
 
     #[rstest]

--- a/gungraun-runner/src/runner/bin_bench.rs
+++ b/gungraun-runner/src/runner/bin_bench.rs
@@ -35,9 +35,9 @@ use crate::api::{
 use crate::error::Error;
 use crate::runner::args;
 use crate::runner::common::{
-    Assistant, AssistantKind, BaselineDataProcessor, Baselines, BenchmarkDataProcessor,
-    BenchmarkSummaries, CapturedOutput, Config, Groups, LoadBaselineDataProcessor, ModulePath,
-    Runner, SaveBaselineDataProcessor,
+    Assistant, AssistantKind, BaselineAndSaveDataProcessor, BaselineDataProcessor, Baselines,
+    BenchmarkDataProcessor, BenchmarkSummaries, CapturedOutput, Config, Groups,
+    LoadBaselineDataProcessor, ModulePath, Runner, SaveBaselineDataProcessor,
 };
 
 #[derive(Debug)]
@@ -101,6 +101,12 @@ struct LoadBaselineBenchmark {
 }
 
 #[derive(Debug)]
+struct BaselineAndSaveBenchmark {
+    baseline: BaselineName,
+    save_baseline: BaselineName,
+}
+
+#[derive(Debug)]
 struct SaveBaselineBenchmark {
     baseline: BaselineName,
 }
@@ -156,6 +162,85 @@ pub trait Benchmark: Debug + Send + Sync {
         force_shutdown: &Arc<AtomicBool>,
         output_path: ToolOutputPath,
     ) -> Result<BenchmarkSummary>;
+}
+
+impl Benchmark for BaselineAndSaveBenchmark {
+    fn default_output_path(
+        &self,
+        bin_bench: &BinBench,
+        config: &Config,
+        group_module_path: &ModulePath,
+        use_temp_dir: bool,
+    ) -> Result<ToolOutputPath> {
+        let kind = if bin_bench.default_tool.has_output_file() {
+            ToolOutputPathKind::BaseOut(self.save_baseline.to_string())
+        } else {
+            ToolOutputPathKind::BaseLog(self.save_baseline.to_string())
+        };
+        let output_path = ToolOutputPath::new(
+            kind,
+            bin_bench.default_tool,
+            &BaselineKind::Name(self.baseline.clone()),
+            &config.meta.target_dir,
+            group_module_path,
+            &bin_bench.name(),
+            use_temp_dir,
+        )?;
+
+        if !use_temp_dir {
+            output_path.init()?;
+        }
+
+        Ok(output_path)
+    }
+
+    fn baselines(&self) -> Baselines {
+        (
+            Some(self.save_baseline.to_string()),
+            Some(self.baseline.to_string()),
+        )
+    }
+
+    fn run(
+        &self,
+        bin_bench: BinBench,
+        config: &Config,
+        captured_output: Option<CapturedOutput>,
+        force_shutdown: &Arc<AtomicBool>,
+        output_path: ToolOutputPath,
+    ) -> Result<BenchmarkSummary> {
+        let header = BinaryBenchmarkHeader::new(&config.meta, &bin_bench);
+        let benchmark_summary = bin_bench.create_benchmark_summary(
+            config,
+            &output_path,
+            &bin_bench.function_name,
+            header.description(),
+            self.baselines(),
+        );
+
+        bin_bench.tools.run(
+            benchmark_summary,
+            config,
+            &bin_bench.command.path,
+            &bin_bench.command.args,
+            &bin_bench.run_options,
+            &output_path,
+            &bin_bench.module_path,
+            captured_output.as_ref(),
+            force_shutdown,
+        )
+    }
+
+    fn data_processor(
+        &self,
+        tools: &ToolConfigs,
+        project_root: &Path,
+        output_path: &ToolOutputPath,
+    ) -> Box<dyn BenchmarkDataProcessor> {
+        Box::new(BaselineAndSaveDataProcessor {
+            analyzers: tools.analyzers(project_root, output_path),
+        })
+    }
 }
 
 impl Benchmark for BaselineBenchmark {
@@ -741,7 +826,14 @@ impl Benchmark for SaveBaselineBenchmark {
 ///
 /// Panics when `--load-baseline` is active but no comparison baseline is configured.
 pub fn benchmark_factory(config: &Config) -> Arc<dyn Benchmark> {
-    if let Some(baseline_name) = &config.meta.args.save_baseline {
+    if let (Some(save_baseline), Some(baseline)) =
+        (&config.meta.args.save_baseline, &config.meta.args.baseline)
+    {
+        Arc::new(BaselineAndSaveBenchmark {
+            baseline: baseline.clone(),
+            save_baseline: save_baseline.clone(),
+        })
+    } else if let Some(baseline_name) = &config.meta.args.save_baseline {
         Arc::new(SaveBaselineBenchmark {
             baseline: baseline_name.clone(),
         })
@@ -805,6 +897,19 @@ mod tests {
             timeout: timeout.into().map(Duration::from_millis),
             kind,
         }
+    }
+
+    #[test]
+    fn test_baseline_and_save_benchmark_uses_different_display_baselines() {
+        let benchmark = BaselineAndSaveBenchmark {
+            baseline: BaselineName("main".to_owned()),
+            save_baseline: BaselineName("pr_1234".to_owned()),
+        };
+
+        assert_eq!(
+            benchmark.baselines(),
+            (Some("pr_1234".to_owned()), Some("main".to_owned()))
+        );
     }
 
     #[rstest]

--- a/gungraun-runner/src/runner/callgrind/flamegraph.rs
+++ b/gungraun-runner/src/runner/callgrind/flamegraph.rs
@@ -36,6 +36,15 @@ pub struct BaselineFlamegraphGenerator {
     pub baseline_kind: BaselineKind,
 }
 
+/// The generator for flamegraphs when comparing one baseline and saving as another baseline.
+#[derive(Debug)]
+pub struct BaselineAndSaveFlamegraphGenerator {
+    /// The baseline to compare with.
+    pub baseline: BaselineName,
+    /// The baseline used to save the current run.
+    pub save_baseline: BaselineName,
+}
+
 /// The main configuration for a flamegraph
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
@@ -155,6 +164,80 @@ impl FlamegraphGenerator for BaselineFlamegraphGenerator {
                     // This unwrap is safe since we always have differential options if the
                     // flamegraph kind is differential
                     flamegraph.differential_options().unwrap(),
+                    *event_kind,
+                    &stacks_lines,
+                )?;
+
+                flamegraph_summary.base_path = Some(output_path.to_base_path().to_path());
+                flamegraph_summary.diff_path = Some(output_path.to_diff_path().to_path());
+            }
+
+            flamegraph_summaries.totals.push(flamegraph_summary);
+        }
+
+        Ok(flamegraph_summaries.totals)
+    }
+}
+
+impl FlamegraphGenerator for BaselineAndSaveFlamegraphGenerator {
+    fn create(
+        &self,
+        flamegraph: &Flamegraph,
+        tool_output_path: &ToolOutputPath,
+        sentinel: Option<&Sentinel>,
+        project_root: &Path,
+    ) -> Result<Vec<FlamegraphSummary>> {
+        debug_assert_eq!(tool_output_path.baseline_name(), Some(&self.baseline));
+        debug_assert_eq!(
+            tool_output_path.loaded_baseline_name(),
+            Some(self.save_baseline.clone())
+        );
+
+        let mut output_path = OutputPath::new(tool_output_path, EventKind::Ir);
+        output_path.init()?;
+        output_path.clear(true)?;
+        output_path.to_diff_path().clear_diffs()?;
+        output_path.set_modifiers(["total"]);
+
+        if flamegraph.config.kind == FlamegraphKind::None
+            || flamegraph.config.event_kinds.is_empty()
+        {
+            return Ok(vec![]);
+        }
+
+        let (maps, base_maps) =
+            flamegraph.parse(tool_output_path, sentinel, project_root, false)?;
+        let Some(total) = total_flamegraph_map_from_parsed(&maps) else {
+            return Ok(vec![]);
+        };
+        let base_total = base_maps
+            .as_ref()
+            .and_then(total_flamegraph_map_from_parsed);
+
+        let mut flamegraph_summaries = FlamegraphSummaries::default();
+        for event_kind in &flamegraph.config.event_kinds {
+            let mut flamegraph_summary = FlamegraphSummary::new(*event_kind);
+            output_path.set_event_kind(*event_kind);
+
+            let stacks_lines = total.to_stack_format(event_kind)?;
+            if flamegraph.is_regular() {
+                Flamegraph::write(
+                    &output_path,
+                    &mut flamegraph.options(*event_kind, output_path.file_name()),
+                    stacks_lines.iter().map(String::as_str),
+                )?;
+                flamegraph_summary.regular_path = Some(output_path.to_path());
+            }
+
+            if let Some(base_total) = &base_total {
+                Flamegraph::create_differential(
+                    &output_path,
+                    &mut flamegraph.options(*event_kind, output_path.to_diff_path().file_name()),
+                    base_total,
+                    flamegraph.differential_options().expect(
+                        "differential options should be present when creating a differential \
+                         flamegraph",
+                    ),
                     *event_kind,
                     &stacks_lines,
                 )?;
@@ -437,16 +520,28 @@ impl OutputPath {
         Ok(())
     }
 
-    /// This method will remove all differential flamegraphs for a specific base or old
+    /// Removes differential flamegraph files for this output path's baseline.
     ///
-    /// The differential flamegraphs with a base can end with the base name
-    /// (`*.diff.base@<name>.svg`) and/or with the parts until `flamegraph` removed start with the
-    /// base name (`base@<name>.diff.*`)
-    pub fn clear_diff(&self) -> Result<()> {
-        let extension = match &self.baseline_kind {
-            BaselineKind::Old => "diff.old.svg".to_owned(),
-            BaselineKind::Name(name) => format!("diff.base@{name}.svg"),
+    /// # Errors
+    ///
+    /// Propagates filesystem errors encountered while reading the output directory or removing
+    /// matching flamegraph files.
+    pub fn clear_diffs(&self) -> Result<()> {
+        let extension = match &self.kind {
+            OutputPathKind::DiffOld => (None, "diff.old.svg".to_owned()),
+            OutputPathKind::DiffBase(name) => {
+                let basename = format!("base@{name}");
+                let extension = format!("diff.{basename}.svg");
+                (Some(basename), extension)
+            }
+            OutputPathKind::DiffBases(first, _) => {
+                let first_basename = format!("base@{first}");
+                let first_extension = format!("diff.{first_basename}.svg");
+                (Some(first_basename), first_extension)
+            }
+            _ => return Ok(()),
         };
+
         for entry in std::fs::read_dir(&self.dir)
             .with_context(|| format!("Failed reading directory '{}'", self.dir.display()))?
         {
@@ -457,25 +552,26 @@ impl OutputPath {
             {
                 let path = entry.path();
 
+                let (basename, extension) = &extension;
                 if suffix.ends_with(extension.as_str()) {
                     std::fs::remove_file(&path).with_context(|| {
                         format!("Failed removing flamegraph file: '{}'", path.display())
                     })?;
+                    continue;
                 }
 
-                if let BaselineKind::Name(name) = &self.baseline_kind {
+                if let Some(name) = &basename {
                     if suffix
                         .split('.')
                         .skip_while(|p| *p != "flamegraph")
                         .take(3)
-                        .eq([
-                            "flamegraph".to_owned(),
-                            format!("base@{name}"),
-                            "diff".to_owned(),
-                        ])
+                        .eq(["flamegraph".to_owned(), name.to_owned(), "diff".to_owned()])
                     {
                         std::fs::remove_file(&path).with_context(|| {
-                            format!("Failed removing flamegraph file: '{}'", path.display())
+                            format!(
+                                "Failed removing other flamegraph file: '{}'",
+                                path.display()
+                            )
                         })?;
                     }
                 } else {
@@ -638,7 +734,7 @@ impl FlamegraphGenerator for SaveBaselineFlamegraphGenerator {
         let mut output_path = OutputPath::new(tool_output_path, EventKind::Ir);
         output_path.init()?;
         output_path.clear(true)?;
-        output_path.clear_diff()?;
+        output_path.to_diff_path().clear_diffs()?;
         output_path.set_modifiers(["total"]);
 
         if flamegraph.config.kind == FlamegraphKind::None

--- a/gungraun-runner/src/runner/common.rs
+++ b/gungraun-runner/src/runner/common.rs
@@ -30,8 +30,8 @@ use crate::error::Error;
 use crate::runner::args::NoCapture;
 use crate::runner::bin_bench::{self, BinBench};
 use crate::runner::callgrind::flamegraph::{
-    BaselineFlamegraphGenerator, Flamegraph, FlamegraphGenerator, LoadBaselineFlamegraphGenerator,
-    SaveBaselineFlamegraphGenerator,
+    BaselineAndSaveFlamegraphGenerator, BaselineFlamegraphGenerator, Flamegraph,
+    FlamegraphGenerator, LoadBaselineFlamegraphGenerator, SaveBaselineFlamegraphGenerator,
 };
 use crate::runner::callgrind::parser::Sentinel;
 use crate::runner::format::{
@@ -86,6 +86,13 @@ pub enum MaxParallel {
     Serial,
     /// Use this as maximum for the amount of parallelism (N >= 2)
     Count(usize),
+}
+
+/// Data processor used when saving current outputs as a baseline.
+#[derive(Debug)]
+pub struct BaselineAndSaveDataProcessor {
+    /// Analyzer pipeline used to parse and process benchmark outputs.
+    pub analyzers: Vec<Analyzer>,
 }
 
 /// Data processor used for regular benchmark runs without explicit baseline save/load mode.
@@ -223,6 +230,33 @@ pub struct CapturedOutput {
 pub trait BenchmarkDataProcessor: std::fmt::Debug + Send {
     /// Returns the analyzer pipeline used for parsing and artifact generation.
     fn analyzers(&self) -> &[Analyzer];
+
+    /// Removes existing output files targeted by this processor.
+    ///
+    /// This clears the active output path and associated log, xtree, and xleak files.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading output directories or removing files fails.
+    fn clear(&self) -> Result<()> {
+        for (_, output_path, _, _, _) in self.analyzers() {
+            output_path.clear()?;
+            if matches!(
+                output_path.kind,
+                ToolOutputPathKind::Out | ToolOutputPathKind::BaseOut(_)
+            ) {
+                output_path.to_log_output().clear()?;
+            }
+            if let Some(path) = output_path.to_xtree_output() {
+                path.clear()?;
+            }
+            if let Some(path) = output_path.to_xleak_output() {
+                path.clear()?;
+            }
+        }
+
+        Ok(())
+    }
 
     /// Copies temporary output files to their final benchmark output location.
     ///
@@ -583,6 +617,71 @@ impl AssistantKind {
             Self::Teardown => "teardown",
         }
         .to_owned()
+    }
+}
+
+impl BenchmarkDataProcessor for BaselineAndSaveDataProcessor {
+    fn finalize(
+        &mut self,
+        benchmark_summary: &mut BenchmarkSummary,
+        config: &Config,
+        header: &Header,
+    ) -> Result<()> {
+        if !self.has_benchmarks() {
+            return Ok(());
+        }
+
+        self.create_benchmark_directory()
+            .and_then(|()| self.remove_summary())
+            // This'll only clear the save baseline but leave the comparison baseline intact
+            .and_then(|()| self.clear())
+            .and_then(|()| self.move_temp())
+            .and_then(|()| self.sanitize())
+            .and_then(|()| self.parse(benchmark_summary, config, header, None))
+            .and_then(|()| self.copy_temp())
+    }
+
+    fn has_benchmarks(&self) -> bool {
+        !self.analyzers.is_empty()
+    }
+
+    fn analyzers(&self) -> &[Analyzer] {
+        &self.analyzers
+    }
+
+    fn generate_flamegraphs(
+        &self,
+        config: &Config,
+        header: &Header,
+        output_path: &ToolOutputPath,
+        flamegraph_config: &ToolFlamegraphConfig,
+        entry_point: &EntryPoint,
+    ) -> Result<Vec<FlamegraphSummary>> {
+        if output_path.tool == ValgrindTool::Callgrind {
+            if let ToolFlamegraphConfig::Callgrind(flamegraph_config) = &flamegraph_config {
+                let save_baseline = output_path.loaded_baseline_name().expect(
+                    "The saved baseline of a baseline-and-save output path should have a name",
+                );
+                let baseline = output_path.baseline_name().cloned().expect(
+                    "The comparison baseline of a baseline-and-save output path should have a name",
+                );
+
+                return BaselineAndSaveFlamegraphGenerator {
+                    baseline,
+                    save_baseline,
+                }
+                .create(
+                    &Flamegraph::new(header.to_title(), flamegraph_config.to_owned()),
+                    output_path,
+                    (*entry_point == EntryPoint::Default)
+                        .then(Sentinel::default)
+                        .as_ref(),
+                    &config.meta.project_root,
+                );
+            }
+        }
+
+        Ok(vec![])
     }
 }
 
@@ -1321,7 +1420,7 @@ impl Groups {
     /// When `ignored` is `true` no per-benchmark lines are emitted because gungraun has no
     /// ignored-benchmark concept (see nextest's custom-harness contract). When `format` is
     /// [`ListFormat::Terse`] the trailing blank line and summary are suppressed so the output is
-    /// directly parseable by `cargo nextest`.
+    /// directly parsable by `cargo nextest`.
     pub fn list(self, format: ListFormat, ignored: bool) {
         let sum = if ignored {
             0

--- a/gungraun-runner/src/runner/format.rs
+++ b/gungraun-runner/src/runner/format.rs
@@ -73,7 +73,7 @@ pub enum OutputFormatKind {
 ///
 /// Mirrors the relevant subset of libtest's `--format` values. Gungraun only varies the trailing
 /// summary line of `--list`: per-benchmark lines are identical in both formats so they remain
-/// parseable by `cargo nextest` and similar libtest-format consumers.
+/// parsable by `cargo nextest` and similar libtest-format consumers.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ListFormat {
     /// Print per-benchmark lines followed by a blank line and the `0 tests, N benchmarks` summary

--- a/gungraun-runner/src/runner/lib_bench.rs
+++ b/gungraun-runner/src/runner/lib_bench.rs
@@ -24,9 +24,18 @@ use crate::api::{
 use crate::error::Error;
 use crate::runner::args;
 use crate::runner::common::{
-    BaselineDataProcessor, Baselines, BenchmarkDataProcessor, BenchmarkSummaries, CapturedOutput,
-    Config, Groups, LoadBaselineDataProcessor, ModulePath, Runner, SaveBaselineDataProcessor,
+    BaselineAndSaveDataProcessor, BaselineDataProcessor, Baselines, BenchmarkDataProcessor,
+    BenchmarkSummaries, CapturedOutput, Config, Groups, LoadBaselineDataProcessor, ModulePath,
+    Runner, SaveBaselineDataProcessor,
 };
+
+/// Implements [`Benchmark`] to compare a [`LibBench`] against one baseline and save the new run as
+/// another baseline.
+#[derive(Debug)]
+pub struct BaselineAndSaveBenchmark {
+    baseline: BaselineName,
+    save_baseline: BaselineName,
+}
 
 /// Implements [`Benchmark`] to run a [`LibBench`] and compare against an earlier [`BenchmarkKind`]
 #[derive(Debug)]
@@ -139,6 +148,87 @@ pub trait Benchmark: Debug + Send + Sync {
         force_shutdown: &Arc<AtomicBool>,
         output_path: ToolOutputPath,
     ) -> Result<BenchmarkSummary>;
+}
+
+impl Benchmark for BaselineAndSaveBenchmark {
+    fn default_output_path(
+        &self,
+        lib_bench: &LibBench,
+        config: &Config,
+        group_module_path: &ModulePath,
+        use_temp_dir: bool,
+    ) -> Result<ToolOutputPath> {
+        let kind = if lib_bench.default_tool.has_output_file() {
+            ToolOutputPathKind::BaseOut(self.save_baseline.to_string())
+        } else {
+            ToolOutputPathKind::BaseLog(self.save_baseline.to_string())
+        };
+
+        let output_path = ToolOutputPath::new(
+            kind,
+            lib_bench.default_tool,
+            &BaselineKind::Name(self.baseline.clone()),
+            &config.meta.target_dir,
+            group_module_path,
+            &lib_bench.name(),
+            use_temp_dir,
+        )?;
+
+        if !use_temp_dir {
+            output_path.init()?;
+        }
+
+        Ok(output_path)
+    }
+
+    fn baselines(&self) -> Baselines {
+        (
+            Some(self.save_baseline.to_string()),
+            Some(self.baseline.to_string()),
+        )
+    }
+
+    fn run(
+        &self,
+        lib_bench: LibBench,
+        config: &Config,
+        main_index: usize,
+        captured_output: Option<CapturedOutput>,
+        force_shutdown: &Arc<AtomicBool>,
+        output_path: ToolOutputPath,
+    ) -> Result<BenchmarkSummary> {
+        let header = LibraryBenchmarkHeader::new(&lib_bench);
+        let benchmark_summary = lib_bench.create_benchmark_summary(
+            config,
+            &output_path,
+            &lib_bench.function_name,
+            header.description(),
+            self.baselines(),
+        );
+
+        lib_bench.tools.run(
+            benchmark_summary,
+            config,
+            &config.bench_bin,
+            &lib_bench.bench_args(main_index),
+            &lib_bench.run_options,
+            &output_path,
+            &lib_bench.module_path,
+            captured_output.as_ref(),
+            force_shutdown,
+        )
+    }
+
+    fn data_processor(
+        &self,
+        tools: &ToolConfigs,
+        project_root: &Path,
+        output_path: &ToolOutputPath,
+    ) -> Box<dyn BenchmarkDataProcessor> {
+        Box::new(BaselineAndSaveDataProcessor {
+            analyzers: tools.analyzers(project_root, output_path),
+        })
+    }
 }
 
 impl Benchmark for BaselineBenchmark {
@@ -543,7 +633,14 @@ impl Benchmark for SaveBaselineBenchmark {
 ///
 /// Panics when `--load-baseline` is active but no comparison baseline is configured.
 pub fn benchmark_factory(config: &Config) -> Arc<dyn Benchmark> {
-    if let Some(baseline_name) = &config.meta.args.save_baseline {
+    if let (Some(save_baseline), Some(baseline)) =
+        (&config.meta.args.save_baseline, &config.meta.args.baseline)
+    {
+        Arc::new(BaselineAndSaveBenchmark {
+            baseline: baseline.clone(),
+            save_baseline: save_baseline.clone(),
+        })
+    } else if let Some(baseline_name) = &config.meta.args.save_baseline {
         Arc::new(SaveBaselineBenchmark {
             baseline: baseline_name.clone(),
         })
@@ -584,4 +681,22 @@ pub fn list(
 /// The top-level method which should be used to initiate running all benchmarks
 pub fn run(benchmark_groups: LibraryBenchmarkGroups, config: Config) -> Result<BenchmarkSummaries> {
     Runner::from_library_benchmark(benchmark_groups, config).and_then(Runner::run)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_baseline_and_save_benchmark_uses_different_display_baselines() {
+        let benchmark = BaselineAndSaveBenchmark {
+            baseline: BaselineName("main".to_owned()),
+            save_baseline: BaselineName("pr_1234".to_owned()),
+        };
+
+        assert_eq!(
+            benchmark.baselines(),
+            (Some("pr_1234".to_owned()), Some("main".to_owned()))
+        );
+    }
 }

--- a/gungraun-runner/src/runner/meta.rs
+++ b/gungraun-runner/src/runner/meta.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{Context, Result, anyhow};
-use clap::Parser;
 use log::debug;
 
 use super::args::CommandLineArgs;
@@ -92,7 +91,7 @@ pub struct Metadata {
 impl Metadata {
     /// Create a `new` Metadata
     pub fn new(raw_command_line_args: &[String], target: &str) -> Result<Self> {
-        let args = CommandLineArgs::parse_from(raw_command_line_args);
+        let args = CommandLineArgs::parse_validated_from(raw_command_line_args);
 
         let arch = std::env::consts::ARCH.to_owned();
         debug!("Detected architecture: {arch}");


### PR DESCRIPTION
This adds support for using `--save-baseline` together with `--baseline`, allowing a run to compare against one named baseline while saving current results under another name.

Summary of changes:

- Allow `--save-baseline` and `--baseline` to be used together.
- Reject `--save-baseline=X --baseline=X` as an invalid combination.

Example:

```shell
cargo bench --bench <benchmark> -- --baseline=main --save-baseline=pr_1234
```

This reads reference data from `main`, saves current data as `pr_1234`, and displays `Baselines: pr_1234|main`.

Closes #338

AI Tools were used to create this PR