### PR TITLE
chore(just): Improve the book-update-help recipe. Use fixed term width

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -465,18 +465,24 @@ book-term-output path:
     output=$(npx ansi-to-html -f#000 "{{ path }}" | head -c -1 | sed 's/#5F5/#42c142/g')
     echo "<pre><code class=\"hljs\">${output}</code></pre>"
 
-# Update the gungraun-runner help text in the guide (Depends on: build-runner; Uses: 'python3', 'prettier' or 'npx prettier')
+# Update the gungraun-runner help text in the guide (Depends on: build-runner, fmt, fmt-prettier; Uses: 'python3', 'prettier' or 'npx prettier')
 [group('guide')]
-book-update-help: build-runner
+book-update-help: build-runner fmt
     #!/usr/bin/env python3
-    import subprocess, pathlib
+    import subprocess, pathlib, os
 
     file_path = "docs/src/cli_and_env/basics.md"
     start_marker = "<!-- start: gungraun-runner-help -->"
     end_marker = "<!-- end: gungraun-runner-help -->"
 
     runner = str(pathlib.Path("target/release/gungraun-runner").resolve())
-    help_text = subprocess.check_output([runner, "--help"], text=True)
+    help_text = subprocess.check_output(
+        [runner, "--help"],
+        text=True,
+        # Enforce a fixed help width for the guide. Keep this in sync with `max_term_width` in
+        # `args.rs`.
+        env={**os.environ, "__GUNGRAUN_TERM_WIDTH": "101"}
+    )
 
     with open(file_path, "r") as f:
         content = f.read()
@@ -490,7 +496,9 @@ book-update-help: build-runner
     with open(file_path, "w") as f:
         f.write(new_content)
 
-# Bump the gungraun version in the book (Uses: 'sed', 'find')
+    subprocess.run(["just", "fmt-prettier"], check=True)
+
+# Bump the gungraun version in the book (Uses: 'sed', 'find', Depends on: book-update-help())
 [group('chore')]
 book-bump old_version new_version:
     #!/usr/bin/env -S sh -e
@@ -510,6 +518,8 @@ book-bump old_version new_version:
     vprefix="s:v${old_version_escaped}:v{{ new_version }}:g"
     find docs/src/ -type f -iname '*.md' -exec sed -Ei -e "$links" -e "$strings" -e "$at" \
         -e "$flag" -e "$vprefix" '{}' \;
+
+    just book-update-help
 
 # Bump the version of gungraun (and gungraun-runner, and the guide), gungraun-macros or the MSRV (Uses: 'cargo', 'grep'; Depends on: book-bump)
 [group('chore')]

--- a/gungraun-runner/src/runner/common.rs
+++ b/gungraun-runner/src/runner/common.rs
@@ -1321,7 +1321,7 @@ impl Groups {
     /// When `ignored` is `true` no per-benchmark lines are emitted because gungraun has no
     /// ignored-benchmark concept (see nextest's custom-harness contract). When `format` is
     /// [`ListFormat::Terse`] the trailing blank line and summary are suppressed so the output is
-    /// directly parseable by `cargo nextest`.
+    /// directly parsable by `cargo nextest`.
     pub fn list(self, format: ListFormat, ignored: bool) {
         let sum = if ignored {
             0

--- a/gungraun-runner/src/runner/format.rs
+++ b/gungraun-runner/src/runner/format.rs
@@ -73,7 +73,7 @@ pub enum OutputFormatKind {
 ///
 /// Mirrors the relevant subset of libtest's `--format` values. Gungraun only varies the trailing
 /// summary line of `--list`: per-benchmark lines are identical in both formats so they remain
-/// parseable by `cargo nextest` and similar libtest-format consumers.
+/// parsable by `cargo nextest` and similar libtest-format consumers.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ListFormat {
     /// Print per-benchmark lines followed by a blank line and the `0 tests, N benchmarks` summary

--- a/gungraun-runner/src/runner/mod.rs
+++ b/gungraun-runner/src/runner/mod.rs
@@ -24,6 +24,9 @@ pub mod envs {
     pub const GUNGRAUN_COLOR: &str = "GUNGRAUN_COLOR";
     /// Set the logging output of Gungraun
     pub const GUNGRAUN_LOG: &str = "GUNGRAUN_LOG";
+
+    /// Internally used to set the terminal width for the --help print usable in just recipes
+    pub const GUNGRAUN_TERM_WIDTH: &str = "__GUNGRAUN_TERM_WIDTH";
 }
 
 pub mod format;
@@ -40,7 +43,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use args::CommandLineArgs;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use common::{BenchmarkSummaries, Config, ModulePath};
 use format::OutputFormatKind;
 use log::debug;
@@ -251,17 +254,34 @@ where
 
 /// Run this benchmark
 pub fn run() -> Result<()> {
-    let runner_args = match Cli::parse()? {
-        Cli::Runner(runner_args) => runner_args,
-        Cli::ShortHelp => {
-            CommandLineArgs::parse_from(["-h"]);
-            return Ok(());
+    // The term width env var is not intended for public usage.
+    let term_width = std::env::var(envs::GUNGRAUN_TERM_WIDTH)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok());
+
+    let runner_args = match (Cli::parse()?, term_width) {
+        (Cli::Runner(runner_args), _) => runner_args,
+        (Cli::ShortHelp, Some(width)) => {
+            return CommandLineArgs::command()
+                .term_width(width)
+                .print_help()
+                .map_err(Into::into);
         }
-        Cli::LongHelp => {
-            CommandLineArgs::parse_from(["--help"]);
-            return Ok(());
+        (Cli::ShortHelp, None) => {
+            return CommandLineArgs::command().print_help().map_err(Into::into);
         }
-        Cli::Version => {
+        (Cli::LongHelp, Some(width)) => {
+            return CommandLineArgs::command()
+                .term_width(width)
+                .print_long_help()
+                .map_err(Into::into);
+        }
+        (Cli::LongHelp, None) => {
+            return CommandLineArgs::command()
+                .print_long_help()
+                .map_err(Into::into);
+        }
+        (Cli::Version, _) => {
             CommandLineArgs::parse_from(["--version"]);
             return Ok(());
         }


### PR DESCRIPTION
Fixes the behavior of `just book-update-help`, as observed in #644, and makes the recipe generally applicable in terminals with a smaller width