### PR TITLE
fix: callgrind parser when missing banner and remove unwraps in parsers

### DIFF
--- a/benchmark-tests/tests/test_tool/test_parse_logfile_header.rs
+++ b/benchmark-tests/tests/test_tool/test_parse_logfile_header.rs
@@ -52,7 +52,7 @@ fn test_parse_logfile_header(#[case] name: &str, #[case] expected_header: Header
         let file = File::open(&path).unwrap();
         let reader = BufReader::new(file);
 
-        let header = parse_header(&path, &mut reader.lines().map(Result::unwrap)).unwrap();
+        let header = parse_header(&path, &mut reader.lines()).unwrap();
         logfile_headers.push(header);
     }
 

--- a/gungraun-runner/src/runner/cachegrind/parser.rs
+++ b/gungraun-runner/src/runner/cachegrind/parser.rs
@@ -35,16 +35,19 @@ pub struct CachegrindProperties {
 /// Parse the callgrind output files header
 pub fn parse_header<I>(iter: &mut I) -> Result<CachegrindProperties>
 where
-    I: Iterator<Item = String>,
+    I: Iterator<Item = std::io::Result<String>>,
 {
     let mut metrics_prototype: Option<Metrics> = None;
     let mut desc: Vec<String> = vec![];
     let mut cmd: Option<String> = None;
 
-    for line in iter.filter(|line| {
+    for line in iter {
+        let line = line?;
         let line = line.trim();
-        !line.is_empty() && !line.starts_with('#')
-    }) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
         match line.split_once(':').map(|(k, v)| (k.trim(), v.trim())) {
             Some(("desc", value)) if !value.starts_with("Option:") => {
                 trace!("Using description '{value}' from line: '{line}'");

--- a/gungraun-runner/src/runner/cachegrind/summary_parser.rs
+++ b/gungraun-runner/src/runner/cachegrind/summary_parser.rs
@@ -36,15 +36,15 @@ impl Parser for SummaryParser {
             path.display()
         );
 
-        let mut iter = BufReader::new(File::open(&path)?)
-            .lines()
-            .map(Result::unwrap);
+        let mut iter = BufReader::new(File::open(&path)?).lines();
 
         let properties = parse_header(&mut iter)
             .map_err(|error| Error::ParseError(path.clone(), error.to_string()))?;
 
         let mut metrics = None;
         for line in iter {
+            let line = line?;
+
             if let Some(suffix) = line.strip_prefix("summary:") {
                 trace!("Found line with summary: '{line}'");
 
@@ -60,9 +60,7 @@ impl Parser for SummaryParser {
             let file = File::open(&logfile)
                 .with_context(|| format!("Error opening log file '{}'", logfile.display()))?;
 
-            let iter = BufReader::new(file)
-                .lines()
-                .map(std::result::Result::unwrap);
+            let iter = BufReader::new(file).lines();
             let header = logfile_parser::parse_header(&logfile, iter)?;
             (header.pid, header.parent_pid)
         } else {

--- a/gungraun-runner/src/runner/callgrind/hashmap_parser.rs
+++ b/gungraun-runner/src/runner/callgrind/hashmap_parser.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Component, Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use log::trace;
 use serde::{Deserialize, Serialize};
 
@@ -137,9 +137,7 @@ impl CallgrindParser for HashMapParser {
 
     #[expect(clippy::too_many_lines)]
     fn parse_single(&self, path: &Path) -> Result<(CallgrindProperties, Self::Output)> {
-        let mut iter = BufReader::new(File::open(path)?)
-            .lines()
-            .map(Result::unwrap);
+        let mut iter = BufReader::new(File::open(path)?).lines();
         let config = parse_header(&mut iter)
             .map_err(|error| Error::ParseError(path.to_owned(), error.to_string()))?;
 
@@ -157,6 +155,7 @@ impl CallgrindParser for HashMapParser {
         // We start within the header
         let mut is_header = true;
         for line in iter {
+            let line = line?;
             let line = line.trim();
 
             if line.is_empty() || line.starts_with('#') {
@@ -191,7 +190,12 @@ impl CallgrindParser for HashMapParser {
                         .is_some_and(|sentinel| sentinel.matches(func))
                     {
                         trace!("Found sentinel: {func}");
-                        sentinel_key = Some(current_id.clone().try_into().expect("A valid id"));
+                        sentinel_key = Some(
+                            current_id
+                                .clone()
+                                .try_into()
+                                .map_err(|error| anyhow!("Malformed file: {error}"))?,
+                        );
                     }
                 }
                 Some(("fi" | "fe", inline)) => {
@@ -214,12 +218,14 @@ impl CallgrindParser for HashMapParser {
                     });
                 }
                 Some(("calls", calls)) => {
-                    let record = cfn_record.as_mut().expect("Valid calls line");
+                    let record = cfn_record
+                        .as_mut()
+                        .ok_or_else(|| anyhow!("Malformed file: A cfn record should be present"))?;
                     record.calls = calls
                         .split_ascii_whitespace()
-                        .take(1)
-                        .map(|s| s.parse::<u64>().unwrap())
-                        .sum();
+                        .next()
+                        .ok_or_else(|| anyhow!("Missing calls count"))?
+                        .parse::<u64>()?;
                 }
                 None if line.starts_with(|c: char| c.is_ascii_digit()) => {
                     let mut metrics = config.metrics_prototype.clone();
@@ -229,15 +235,20 @@ impl CallgrindParser for HashMapParser {
                     )?;
 
                     if let Some(cfn_record) = cfn_record.take() {
+                        let id = cfn_record.id.ok_or_else(|| {
+                            anyhow!("Malformed file: A cfn record id should be present")
+                        })?;
                         cfn_totals
-                            .entry(cfn_record.id.expect("cfn record id must be present"))
+                            .entry(id)
                             .and_modify(|value| value.metrics.add(&metrics))
                             .or_insert(Value {
                                 metrics: metrics.clone(),
                             });
                     }
 
-                    let id = current_id.try_into().expect("A valid id");
+                    let id = current_id
+                        .try_into()
+                        .map_err(|error| anyhow!("Malformed file: {error}"))?;
                     match fn_totals.get_mut(&id) {
                         Some(value) => value.metrics.add(&metrics),
                         None => {
@@ -252,7 +263,7 @@ impl CallgrindParser for HashMapParser {
                 None if line.starts_with("totals:") || line.starts_with("summary:") => {
                     // we ignore these
                 }
-                Some(_) | None => panic!("Malformed line: '{line}'"),
+                Some(_) | None => return Err(anyhow!("Malformed line: '{line}'")),
             }
         }
 

--- a/gungraun-runner/src/runner/callgrind/parser.rs
+++ b/gungraun-runner/src/runner/callgrind/parser.rs
@@ -188,14 +188,17 @@ impl From<Sentinel> for String {
 /// Parse the callgrind output files header
 pub fn parse_header<I>(iter: &mut I) -> Result<CallgrindProperties>
 where
-    I: Iterator<Item = String>,
+    I: Iterator<Item = std::io::Result<String>>,
 {
-    if !iter
-        .by_ref()
-        .find(|l| !l.trim().is_empty())
-        .ok_or_else(|| anyhow!("Empty file"))?
-        .contains("callgrind format")
-    {
+    let first_non_empty = loop {
+        match iter.next().transpose()? {
+            Some(line) if line.trim().is_empty() => {}
+            Some(line) => break line,
+            None => return Err(anyhow!("Empty file")),
+        }
+    };
+
+    if !first_non_empty.contains("callgrind format") {
         warn!("Missing file format specifier. Assuming callgrind format.");
     }
 
@@ -208,10 +211,13 @@ where
     let mut cmd: Option<String> = None;
     let mut creator: Option<String> = None;
 
-    for line in iter.filter(|line| {
+    for line in std::iter::once(Ok(first_non_empty)).chain(iter) {
+        let line = line?;
         let line = line.trim();
-        !line.is_empty() && !line.starts_with('#')
-    }) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
         match line.split_once(':').map(|(k, v)| (k.trim(), v.trim())) {
             Some(("version", version)) if version != "1" => {
                 return Err(anyhow!(
@@ -220,15 +226,15 @@ where
             }
             Some(("pid", value)) => {
                 trace!("Using pid '{value}' from line: '{line}'");
-                pid = Some(value.parse::<i32>().unwrap());
+                pid = Some(value.parse::<i32>()?);
             }
             Some(("thread", value)) => {
                 trace!("Using thread '{value}' from line: '{line}'");
-                thread = Some(value.parse::<usize>().unwrap());
+                thread = Some(value.parse::<usize>()?);
             }
             Some(("part", value)) => {
                 trace!("Using part '{value}' from line: '{line}'");
-                part = Some(value.parse::<u64>().unwrap());
+                part = Some(value.parse::<u64>()?);
             }
             Some(("desc", value)) if !value.starts_with("Option:") => {
                 trace!("Using description '{value}' from line: '{line}'");
@@ -282,6 +288,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::io::{BufRead, BufReader, Cursor, ErrorKind};
+
     use rstest::rstest;
 
     use super::*;
@@ -316,5 +324,51 @@ mod tests {
     #[case::hex("0x*", "0x00000000000083f0")]
     fn test_sentinel_from_glob_matches(#[case] input: &str, #[case] haystack: &str) {
         assert!(Sentinel::new(input).matches(haystack));
+    }
+
+    #[test]
+    fn parse_header_when_format_banner_is_present() {
+        let mut lines = [
+            Ok(String::from("# callgrind format")),
+            Ok(String::from("pid: 123")),
+            Ok(String::from("cmd: bench command")),
+            Ok(String::from("events: Ir Dr Dw")),
+        ]
+        .into_iter();
+
+        let header = parse_header(&mut lines).unwrap();
+
+        assert_eq!(header.pid, Some(123));
+        assert_eq!(header.cmd.as_deref(), Some("bench command"));
+        assert_eq!(header.metrics_prototype.0.len(), 3);
+    }
+
+    #[test]
+    fn parse_header_when_format_banner_is_missing() {
+        let mut lines = [
+            Ok(String::new()),
+            Ok(String::from("pid: 123")),
+            Ok(String::from("cmd: bench command")),
+            Ok(String::from("events: Ir Dr Dw")),
+        ]
+        .into_iter();
+
+        let header = parse_header(&mut lines).unwrap();
+
+        assert_eq!(header.pid, Some(123));
+        assert_eq!(header.cmd.as_deref(), Some("bench command"));
+        assert_eq!(header.metrics_prototype.0.len(), 3);
+    }
+
+    #[test]
+    fn parse_header_when_invalid_utf8_then_error_but_not_panic() {
+        // Invalid utf8
+        let bytes = b"\n\xFF\npid: 123\nevents: Ir Dr Dw\n".to_vec();
+        let mut lines = BufReader::new(Cursor::new(bytes)).lines();
+
+        let err = parse_header(&mut lines).unwrap_err();
+        let io_err = err.downcast_ref::<std::io::Error>().unwrap();
+
+        assert_eq!(io_err.kind(), ErrorKind::InvalidData);
     }
 }

--- a/gungraun-runner/src/runner/callgrind/summary_parser.rs
+++ b/gungraun-runner/src/runner/callgrind/summary_parser.rs
@@ -54,15 +54,15 @@ impl CallgrindParser for SummaryParser {
             path.display()
         );
 
-        let mut iter = BufReader::new(File::open(path)?)
-            .lines()
-            .map(Result::unwrap);
+        let mut iter = BufReader::new(File::open(path)?).lines();
 
         let properties = parse_header(&mut iter)
             .map_err(|error| Error::ParseError(path.to_owned(), error.to_string()))?;
 
         let mut metrics = None;
         for line in iter {
+            let line = line?;
+
             if let Some(suffix) = line.strip_prefix("summary:") {
                 trace!("Found line with summary: '{line}'");
 

--- a/gungraun-runner/src/runner/dhat/json_parser.rs
+++ b/gungraun-runner/src/runner/dhat/json_parser.rs
@@ -48,9 +48,7 @@ impl Parser for JsonParser {
             let file = File::open(&logfile)
                 .with_context(|| format!("Error opening dhat log file '{}'", logfile.display()))?;
 
-            let iter = BufReader::new(file)
-                .lines()
-                .map(std::result::Result::unwrap);
+            let iter = BufReader::new(file).lines();
             let header = logfile_parser::parse_header(&logfile, iter)?;
 
             assert_eq!(

--- a/gungraun-runner/src/runner/dhat/logfile_parser.rs
+++ b/gungraun-runner/src/runner/dhat/logfile_parser.rs
@@ -187,8 +187,7 @@ impl Parser for DhatLogfileParser {
 
         let mut iter = BufReader::new(file)
             .lines()
-            .map(std::result::Result::unwrap)
-            .skip_while(|l| l.trim().is_empty());
+            .skip_while(|l| l.as_ref().is_ok_and(|l| l.trim().is_empty()));
 
         let header = parse_header(&path, &mut iter)?;
 
@@ -197,6 +196,7 @@ impl Parser for DhatLogfileParser {
 
         let mut state = State::HeaderSpace;
         for line in iter {
+            let line = line?;
             if !Self::parse_line(&line, &mut state, &mut metrics, &mut details)? {
                 break;
             }

--- a/gungraun-runner/src/runner/tool/error_metric_parser.rs
+++ b/gungraun-runner/src/runner/tool/error_metric_parser.rs
@@ -46,8 +46,7 @@ impl Parser for ErrorMetricLogfileParser {
 
         let mut iter = BufReader::new(file)
             .lines()
-            .map(std::result::Result::unwrap)
-            .skip_while(|l| l.trim().is_empty());
+            .skip_while(|l| l.as_ref().is_ok_and(|l| l.trim().is_empty()));
 
         let header = parse_header(&path, &mut iter)?;
 
@@ -63,6 +62,7 @@ impl Parser for ErrorMetricLogfileParser {
 
         let mut state = State::HeaderSpace;
         for line in iter {
+            let line = line?;
             match &state {
                 State::HeaderSpace if EMPTY_LINE_RE.is_match(&line) => {}
                 State::HeaderSpace | State::Body => {

--- a/gungraun-runner/src/runner/tool/generic_parser.rs
+++ b/gungraun-runner/src/runner/tool/generic_parser.rs
@@ -33,14 +33,14 @@ impl Parser for GenericLogfileParser {
 
         let mut iter = BufReader::new(file)
             .lines()
-            .map(std::result::Result::unwrap)
-            .skip_while(|l| l.trim().is_empty());
+            .skip_while(|l| l.as_ref().is_ok_and(|l| l.trim().is_empty()));
 
         let header = parse_header(&path, &mut iter)?;
         let mut details = vec![];
 
         let mut state = State::HeaderSpace;
         for line in iter {
+            let line = line?;
             match &state {
                 State::HeaderSpace if EMPTY_LINE_RE.is_match(&line) => {}
                 State::HeaderSpace | State::Body => {

--- a/gungraun-runner/src/runner/tool/logfile_parser.rs
+++ b/gungraun-runner/src/runner/tool/logfile_parser.rs
@@ -46,9 +46,9 @@ pub fn extract_pid(line: &str) -> Result<i32> {
 /// The logfile header is the same for all tools
 pub fn parse_header<I>(path: &Path, mut lines: I) -> Result<Header>
 where
-    I: Iterator<Item = String>,
+    I: Iterator<Item = std::io::Result<String>>,
 {
-    let next = lines.next();
+    let next = lines.next().transpose()?;
 
     let (pid, next) = if let Some(next) = next {
         (extract_pid(&next)?, next)
@@ -58,7 +58,8 @@ where
 
     let mut parent_pid = None;
     let mut command = None;
-    for line in std::iter::once(next).chain(lines) {
+    for line in std::iter::once(Ok(next)).chain(lines) {
+        let line = line?;
         if EMPTY_LINE_RE.is_match(&line) {
             // The header is separated from the body by at least one empty line. The first
             // empty line is removed from the iterator.

--- a/gungraun-runner/src/runner/tool/path.rs
+++ b/gungraun-runner/src/runner/tool/path.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 use tempfile::{Builder, TempDir};
 
 use crate::api::ValgrindTool;
-use crate::runner::callgrind::parser::parse_header;
+use crate::runner::callgrind;
 use crate::runner::common::ModulePath;
 use crate::runner::summary::{BaselineKind, BaselineName};
 use crate::util::truncate_str_utf8;
@@ -906,10 +906,8 @@ impl ToolOutputPath {
                     .as_str();
 
                 if out_type == ".out" {
-                    let properties = parse_header(
-                        &mut BufReader::new(File::open(entry.path())?)
-                            .lines()
-                            .map(Result::unwrap),
+                    let properties = callgrind::parser::parse_header(
+                        &mut BufReader::new(File::open(entry.path())?).lines(),
                     )?;
                     if let Some(bases) = groups.get_mut(out_type) {
                         if let Some(pids) = bases.get_mut(&base) {


### PR DESCRIPTION
Summary of changes:

* Fix callgrind parser when missing the format banner
* Propagate `lines()` read errors through the callgrind/cachegrind/logfile parsers, remove hidden parser `unwrap`/panic paths in callgrind hashmap parsing, update call sites to pass fallible iterators directly

These are all defensive fixes, with little to no occurrences in real situations. In case of malformed files or utf8 errors, proper error propagation is now in use.

AI Tools were used to create this PR