### PR TITLE
chore(deps): Increase bincode version in Cargo.toml. Keep it locked to 2.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.19.2"
 [workspace.dependencies]
 anyhow = { version = "1.0.46" }
 assert_cmd = { version = "2.0" }
-bincode-next = { version = ">2,<=3.1", default-features = false, features = [
+bincode-next = { version = ">=2,<=3.1", default-features = false, features = [
   "serde",
   "std",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.19.2"
 [workspace.dependencies]
 anyhow = { version = "1.0.46" }
 assert_cmd = { version = "2.0" }
-bincode-next = { version = "2", default-features = false, features = [
+bincode-next = { version = ">2,<=3.1", default-features = false, features = [
   "serde",
   "std",
 ] }


### PR DESCRIPTION
bincode v3 is backwards-compatible to v2, so allowing both is ok. Keep it locked for gungraun-runner to 2.1.0 due to the MSRV.