### PR TITLE
fix(regression): Do not apply a default if only fail-fast is set

### DIFF
--- a/benchmark-tests/Cargo.toml
+++ b/benchmark-tests/Cargo.toml
@@ -27,7 +27,7 @@ either-or-both = { workspace = true }
 fs_extra = { workspace = true }
 glob = { workspace = true }
 gungraun = { path = "../gungraun", features = ["client_requests"] }
-gungraun-runner = { path = "../gungraun-runner" }
+gungraun-runner = { path = "../gungraun-runner", features = ["__fixtures"] }
 minijinja = { workspace = true }
 once_cell = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/benchmark-tests/tests/test_dhat/test_json_parser.rs
+++ b/benchmark-tests/tests/test_dhat/test_json_parser.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use gungraun_runner::api::{EntryPoint, SanitizeOutput, ValgrindTool};
+use gungraun_runner::fixtures::tool_output_path_f;
 use gungraun_runner::runner::dhat::json_parser::{JsonParser, parse};
 use gungraun_runner::runner::dhat::model::DhatData;
 use gungraun_runner::runner::dhat::tree::{RootTree, Tree};
@@ -11,7 +12,6 @@ use pretty_assertions::assert_eq;
 use tempfile::{TempDir, tempdir};
 
 use crate::util::common::Fixtures;
-use crate::util::fixtures::tool_output_path_f;
 
 const DHAT_FIXTURE: &str = "dhat/dhat.with_entry_point.out";
 

--- a/benchmark-tests/tests/test_path/test_tool_output_path.rs
+++ b/benchmark-tests/tests/test_path/test_tool_output_path.rs
@@ -1,9 +1,8 @@
 use ValgrindTool::*;
 use gungraun::ValgrindTool;
+use gungraun_runner::fixtures::tool_output_path_f;
 use rstest::rstest;
 use tempfile::tempdir;
-
-use crate::util::fixtures::tool_output_path_f;
 
 #[rstest]
 #[case::empty(

--- a/benchmark-tests/tests/test_tasks/test_process_handler.rs
+++ b/benchmark-tests/tests/test_tasks/test_process_handler.rs
@@ -3,6 +3,11 @@ use std::time::Duration;
 
 use gungraun::ExitWith;
 use gungraun_runner::error::Error;
+use gungraun_runner::fixtures::{
+    assistant_f, config_f, force_shutdown_f, module_path_f, process_handler_f, run_options_f,
+    setup_child_f, teardown_child_f, test_file_f, tool_command_child_f, tool_command_f,
+    tool_config_f, tool_output_path_f,
+};
 use gungraun_runner::runner::args::NoCapture;
 use gungraun_runner::runner::common::AssistantKind;
 use gungraun_runner::runner::tool::run::RunOptions;
@@ -13,11 +18,6 @@ use crate::assert_not_elapsed;
 use crate::util::common::{
     BENCH_BIN_FAKE_EXE, ECHO_EXE, EXIT_WITH_EXE, FILE_EXISTS_EXE, TIMEOUT_EXE,
     cleanup_test_process_handler, tool_output_path_dump,
-};
-use crate::util::fixtures::{
-    assistant_f, config_f, force_shutdown_f, module_path_f, process_handler_f, run_options_f,
-    setup_child_f, teardown_child_f, test_file_f, tool_command_child_f, tool_command_f,
-    tool_config_f, tool_output_path_f,
 };
 
 #[test]

--- a/benchmark-tests/tests/test_tool/test_config.rs
+++ b/benchmark-tests/tests/test_tool/test_config.rs
@@ -1,6 +1,5 @@
 use gungraun_runner::api::{Tool, Tools, ValgrindTool};
-
-use crate::util::fixtures::tool_configs_f;
+use gungraun_runner::fixtures::tool_configs_f;
 
 #[test]
 fn test_tool_configs_apply_cli_valgrind_args_to_default_tool() {

--- a/benchmark-tests/tests/util/mod.rs
+++ b/benchmark-tests/tests/util/mod.rs
@@ -1,2 +1,1 @@
 pub mod common;
-pub mod fixtures;

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,9 @@ feature-depth = 1
 ignore = [
   # warning that paste (transitive from polonius) is unmaintained
   "RUSTSEC-2024-0436",
+  # transitive from inferno which needs to update quick-xml to 0.41
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
   # https://rustsec.org/advisories/RUSTSEC-2024-0421
   #"RUSTSEC-0000-0000",
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/gungraun-runner/Cargo.toml
+++ b/gungraun-runner/Cargo.toml
@@ -21,6 +21,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
+__fixtures = ["dep:bon", "runner"]
 api = ["dep:serde", "either-or-both/serde"]
 default = ["runner"]
 runner = [
@@ -65,6 +66,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 anyhow = { workspace = true, optional = true }
 bincode-next = { workspace = true, optional = true }
+bon = { workspace = true, optional = true }
 cargo_metadata = { workspace = true, optional = true }
 clap = { workspace = true, optional = true, features = [
   "derive",

--- a/gungraun-runner/fixtures/api.rs
+++ b/gungraun-runner/fixtures/api.rs
@@ -1,0 +1,33 @@
+//! Fixtures for types from the api module
+
+use bon::builder;
+
+use crate::api::{
+    CachegrindMetrics, CachegrindRegressionConfig, DhatMetrics, DhatRegressionConfig, Limit,
+};
+
+#[builder(finish_fn = "fixture")]
+pub fn cachegrind_regression_config_f(
+    soft_limits: Option<Vec<(CachegrindMetrics, f64)>>,
+    hard_limits: Option<Vec<(CachegrindMetrics, Limit)>>,
+    fail_fast: Option<bool>,
+) -> CachegrindRegressionConfig {
+    CachegrindRegressionConfig {
+        soft_limits: soft_limits.map_or_else(Vec::default, |s| s.into_iter().collect()),
+        hard_limits: hard_limits.map_or_else(Vec::default, |h| h.into_iter().collect()),
+        fail_fast,
+    }
+}
+
+#[builder(finish_fn = "fixture")]
+pub fn dhat_regression_config_f(
+    soft_limits: Option<Vec<(DhatMetrics, f64)>>,
+    hard_limits: Option<Vec<(DhatMetrics, Limit)>>,
+    fail_fast: Option<bool>,
+) -> DhatRegressionConfig {
+    DhatRegressionConfig {
+        soft_limits: soft_limits.map_or_else(Vec::default, |s| s.into_iter().collect()),
+        hard_limits: hard_limits.map_or_else(Vec::default, |h| h.into_iter().collect()),
+        fail_fast,
+    }
+}

--- a/gungraun-runner/fixtures/mod.rs
+++ b/gungraun-runner/fixtures/mod.rs
@@ -1,3 +1,10 @@
+//! This module contains test fixtures for gungraun-runner types
+//!
+//! The fixtures are usable via the `__fixtures` feature gate in other packages than gungraun-runner
+//! and in the gungraun-runner crate itself within cfg(test) modules
+
+#![allow(missing_docs)]
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -9,20 +16,20 @@ use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use bon::builder;
-use gungraun::{EntryPoint, ExitWith, SanitizeOutput, ValgrindTool};
-use gungraun_runner::api::{RawToolArgs, Tools};
-use gungraun_runner::runner::common::{Assistant, AssistantKind, Config, ModulePath};
-use gungraun_runner::runner::format::OutputFormat;
-use gungraun_runner::runner::meta::Metadata;
-use gungraun_runner::runner::tasks::ProcessHandler;
-use gungraun_runner::runner::tool::args::ToolArgs;
-use gungraun_runner::runner::tool::config::{ToolConfig, ToolConfigs, ToolFlamegraphConfig};
-use gungraun_runner::runner::tool::path::{ToolOutputPath, ToolOutputPathKind};
-use gungraun_runner::runner::tool::regression::ToolRegressionConfig;
-use gungraun_runner::runner::tool::run::{RunOptions, ToolCommand, ToolCommandChild};
-use gungraun_runner::summary::model::BaselineKind;
 
-use crate::util::common::DEFAULT_TOOL;
+use crate::api::{EntryPoint, ExitWith, RawToolArgs, SanitizeOutput, Tools, ValgrindTool};
+use crate::runner::common::{Assistant, AssistantKind, Config, ModulePath};
+use crate::runner::format::OutputFormat;
+use crate::runner::meta::Metadata;
+use crate::runner::tasks::ProcessHandler;
+use crate::runner::tool::args::ToolArgs;
+use crate::runner::tool::config::{ToolConfig, ToolConfigs, ToolFlamegraphConfig};
+use crate::runner::tool::path::{ToolOutputPath, ToolOutputPathKind};
+use crate::runner::tool::regression::ToolRegressionConfig;
+use crate::runner::tool::run::{RunOptions, ToolCommand, ToolCommandChild};
+use crate::summary::model::BaselineKind;
+
+pub const DEFAULT_TOOL: ValgrindTool = ValgrindTool::Callgrind;
 
 #[builder(finish_fn = "fixture")]
 pub fn assistant_f(kind: AssistantKind) -> Assistant {
@@ -38,7 +45,7 @@ pub fn config_f(
     Config {
         bench_bin: bench_bin.to_path_buf(),
         bench_file: bench_file
-            .map_or_else(|| PathBuf::from("does_not_exist.rs"), |f| f.to_path_buf()),
+            .map_or_else(|| PathBuf::from("does_not_exist.rs"), Path::to_path_buf),
         meta: metadata.map_or_else(|| metadata_f().fixture(), Clone::clone),
         module_path: ModulePath::new("does_not_exist"),
         package_dir: PathBuf::from("test_package"),
@@ -309,7 +316,7 @@ pub fn tool_output_path_f(
     if !files.is_empty() {
         let dir = path.dest_dir();
         for (path, content) in files {
-            std::fs::write(dir.join(path), content).unwrap()
+            std::fs::write(dir.join(path), content).unwrap();
         }
     }
 

--- a/gungraun-runner/fixtures/mod.rs
+++ b/gungraun-runner/fixtures/mod.rs
@@ -5,6 +5,8 @@
 
 #![allow(missing_docs)]
 
+pub mod api;
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -17,8 +19,14 @@ use std::time::Duration;
 
 use bon::builder;
 
-use crate::api::{EntryPoint, ExitWith, RawToolArgs, SanitizeOutput, Tools, ValgrindTool};
+use crate::api::{
+    CachegrindMetric, DhatMetric, EntryPoint, ExitWith, RawToolArgs, SanitizeOutput, Tools,
+    ValgrindTool,
+};
+use crate::metrics::model::Metric;
+use crate::runner::cachegrind::regression::CachegrindRegressionConfig;
 use crate::runner::common::{Assistant, AssistantKind, Config, ModulePath};
+use crate::runner::dhat::regression::DhatRegressionConfig;
 use crate::runner::format::OutputFormat;
 use crate::runner::meta::Metadata;
 use crate::runner::tasks::ProcessHandler;
@@ -80,6 +88,32 @@ pub fn command_child_f(exe: &Path, args: Option<&[&str]>, stdout: Option<StdStdi
     command
         .spawn()
         .expect("Spawning the process should succeed.")
+}
+
+#[builder(finish_fn = "fixture")]
+pub fn cachegrind_regression_config_f(
+    soft_limits: Option<Vec<(CachegrindMetric, f64)>>,
+    hard_limits: Option<Vec<(CachegrindMetric, Metric)>>,
+    fail_fast: Option<bool>,
+) -> CachegrindRegressionConfig {
+    CachegrindRegressionConfig {
+        soft_limits: soft_limits.map_or_else(Vec::default, |s| s.into_iter().collect()),
+        hard_limits: hard_limits.map_or_else(Vec::default, |h| h.into_iter().collect()),
+        fail_fast: fail_fast.unwrap_or(false),
+    }
+}
+
+#[builder(finish_fn = "fixture")]
+pub fn dhat_regression_config_f(
+    soft_limits: Option<Vec<(DhatMetric, f64)>>,
+    hard_limits: Option<Vec<(DhatMetric, Metric)>>,
+    fail_fast: Option<bool>,
+) -> DhatRegressionConfig {
+    DhatRegressionConfig {
+        soft_limits: soft_limits.map_or_else(Vec::default, |s| s.into_iter().collect()),
+        hard_limits: hard_limits.map_or_else(Vec::default, |h| h.into_iter().collect()),
+        fail_fast: fail_fast.unwrap_or(false),
+    }
 }
 
 #[builder(finish_fn = "fixture")]

--- a/gungraun-runner/src/lib.rs
+++ b/gungraun-runner/src/lib.rs
@@ -8,6 +8,9 @@
 pub mod api;
 #[cfg(feature = "runner")]
 pub mod error;
+#[cfg(any(feature = "__fixtures", test))]
+#[path = "../fixtures/mod.rs"]
+pub mod fixtures;
 #[cfg(any(feature = "runner", feature = "summary", feature = "schema"))]
 pub mod metrics;
 #[cfg(feature = "runner")]

--- a/gungraun-runner/src/runner/cachegrind/regression.rs
+++ b/gungraun-runner/src/runner/cachegrind/regression.rs
@@ -91,32 +91,27 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::api::CachegrindMetrics;
+    use crate::api::CachegrindMetric::*;
+    use crate::api::{CachegrindMetrics, Limit};
+    use crate::fixtures::api::cachegrind_regression_config_f as api_cachegrind_regression_config_f;
+    use crate::fixtures::cachegrind_regression_config_f;
 
     #[rstest]
-    #[case(
-        api::CachegrindRegressionConfig {
-            soft_limits: Vec::default(),
-            hard_limits: Vec::default(),
-            fail_fast: Some(true),
-        },
-        CachegrindRegressionConfig {
-            soft_limits: Vec::default(),
-            hard_limits: Vec::default(),
-            fail_fast: true,
-        }
+    #[case::fail_fast(
+        api_cachegrind_regression_config_f().fail_fast(true).fixture(),
+        cachegrind_regression_config_f().fail_fast(true).fixture(),
     )]
-    #[case(
-        api::CachegrindRegressionConfig {
-            soft_limits: vec![(CachegrindMetrics::from(CachegrindMetric::Ir), 5f64)],
-            hard_limits: Vec::default(),
-            fail_fast: Some(true),
-        },
-        CachegrindRegressionConfig {
-            soft_limits: vec![(CachegrindMetric::Ir, 5f64)],
-            hard_limits: Vec::default(),
-            fail_fast: true,
-        }
+    #[case::soft_limit(
+        api_cachegrind_regression_config_f()
+            .soft_limits(vec![(CachegrindMetrics::from(Ir), 5f64)])
+            .fixture(),
+        cachegrind_regression_config_f().soft_limits(vec![(Ir, 5f64)]).fixture(),
+    )]
+    #[case::hard_limit(
+        api_cachegrind_regression_config_f()
+            .hard_limits(vec![(CachegrindMetrics::from(Ir), Limit::Int(10))])
+            .fixture(),
+        cachegrind_regression_config_f().hard_limits(vec![(Ir, Metric::Int(10))]).fixture(),
     )]
     fn test_try_from_regression_config(
         #[case] input: api::CachegrindRegressionConfig,

--- a/gungraun-runner/src/runner/cachegrind/regression.rs
+++ b/gungraun-runner/src/runner/cachegrind/regression.rs
@@ -54,43 +54,76 @@ impl TryFrom<api::CachegrindRegressionConfig> for CachegrindRegressionConfig {
             fail_fast,
         } = value;
 
-        let (soft_limits, hard_limits) = if soft_limits.is_empty() && hard_limits.is_empty() {
-            (
-                IndexMap::from([(CachegrindMetric::Ir, 10f64)]),
-                IndexMap::new(),
-            )
-        } else {
-            let hard_limits = hard_limits
-                .into_iter()
-                .flat_map(|(cachegrind_metrics, metric)| {
-                    IndexSet::from(cachegrind_metrics)
-                        .into_iter()
-                        .map(move |metric_kind| {
-                            Metric::from(metric)
-                                .try_convert(metric_kind)
-                                .ok_or_else(|| {
-                                    format!(
-                                        "Invalid hard limit for \
-                                         '{metric_kind:?}/{cachegrind_metrics:?}': Expected a \
-                                         'Int' but found '{metric:?}'"
-                                    )
-                                })
-                        })
-                })
-                .collect::<Result<IndexMap<CachegrindMetric, Metric>, String>>()?;
+        let hard_limits = hard_limits
+            .into_iter()
+            .flat_map(|(cachegrind_metrics, metric)| {
+                IndexSet::from(cachegrind_metrics)
+                    .into_iter()
+                    .map(move |metric_kind| {
+                        Metric::from(metric)
+                            .try_convert(metric_kind)
+                            .ok_or_else(|| {
+                                format!(
+                                    "Invalid hard limit for \
+                                     '{metric_kind:?}/{cachegrind_metrics:?}': Expected a 'Int' \
+                                     but found '{metric:?}'"
+                                )
+                            })
+                    })
+            })
+            .collect::<Result<IndexMap<CachegrindMetric, Metric>, String>>()?;
 
-            let soft_limits = soft_limits
-                .into_iter()
-                .flat_map(|(m, l)| IndexSet::from(m).into_iter().map(move |e| (e, l)))
-                .collect::<IndexMap<_, _>>();
-
-            (soft_limits, hard_limits)
-        };
+        let soft_limits = soft_limits
+            .into_iter()
+            .flat_map(|(m, l)| IndexSet::from(m).into_iter().map(move |e| (e, l)))
+            .collect::<IndexMap<_, _>>();
 
         Ok(Self {
             soft_limits: soft_limits.into_iter().collect(),
             hard_limits: hard_limits.into_iter().collect(),
             fail_fast: fail_fast.unwrap_or(false),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::api::CachegrindMetrics;
+
+    #[rstest]
+    #[case(
+        api::CachegrindRegressionConfig {
+            soft_limits: Vec::default(),
+            hard_limits: Vec::default(),
+            fail_fast: Some(true),
+        },
+        CachegrindRegressionConfig {
+            soft_limits: Vec::default(),
+            hard_limits: Vec::default(),
+            fail_fast: true,
+        }
+    )]
+    #[case(
+        api::CachegrindRegressionConfig {
+            soft_limits: vec![(CachegrindMetrics::from(CachegrindMetric::Ir), 5f64)],
+            hard_limits: Vec::default(),
+            fail_fast: Some(true),
+        },
+        CachegrindRegressionConfig {
+            soft_limits: vec![(CachegrindMetric::Ir, 5f64)],
+            hard_limits: Vec::default(),
+            fail_fast: true,
+        }
+    )]
+    fn test_try_from_regression_config(
+        #[case] input: api::CachegrindRegressionConfig,
+        #[case] expected: CachegrindRegressionConfig,
+    ) {
+        let config = CachegrindRegressionConfig::try_from(input).unwrap();
+
+        assert_eq!(config, expected);
     }
 }

--- a/gungraun-runner/src/runner/callgrind/regression.rs
+++ b/gungraun-runner/src/runner/callgrind/regression.rs
@@ -57,35 +57,29 @@ impl TryFrom<api::CallgrindRegressionConfig> for CallgrindRegressionConfig {
             fail_fast,
         } = value;
 
-        let (soft_limits, hard_limits) = if soft_limits.is_empty() && hard_limits.is_empty() {
-            (IndexMap::from([(EventKind::Ir, 10f64)]), IndexMap::new())
-        } else {
-            let hard_limits = hard_limits
-                .into_iter()
-                .flat_map(|(callgrind_metrics, metric)| {
-                    IndexSet::from(callgrind_metrics)
-                        .into_iter()
-                        .map(move |metric_kind| {
-                            Metric::from(metric)
-                                .try_convert(metric_kind)
-                                .ok_or_else(|| {
-                                    format!(
-                                        "Invalid hard limit for \
-                                         '{metric_kind:?}/{callgrind_metrics:?}': Expected a \
-                                         'Int' but found '{metric:?}'"
-                                    )
-                                })
-                        })
-                })
-                .collect::<Result<IndexMap<EventKind, Metric>, String>>()?;
+        let hard_limits = hard_limits
+            .into_iter()
+            .flat_map(|(callgrind_metrics, metric)| {
+                IndexSet::from(callgrind_metrics)
+                    .into_iter()
+                    .map(move |metric_kind| {
+                        Metric::from(metric)
+                            .try_convert(metric_kind)
+                            .ok_or_else(|| {
+                                format!(
+                                    "Invalid hard limit for \
+                                     '{metric_kind:?}/{callgrind_metrics:?}': Expected a 'Int' \
+                                     but found '{metric:?}'"
+                                )
+                            })
+                    })
+            })
+            .collect::<Result<IndexMap<EventKind, Metric>, String>>()?;
 
-            let soft_limits = soft_limits
-                .into_iter()
-                .flat_map(|(m, l)| IndexSet::from(m).into_iter().map(move |e| (e, l)))
-                .collect::<IndexMap<_, _>>();
-
-            (soft_limits, hard_limits)
-        };
+        let soft_limits = soft_limits
+            .into_iter()
+            .flat_map(|(m, l)| IndexSet::from(m).into_iter().map(move |e| (e, l)))
+            .collect::<IndexMap<_, _>>();
 
         Ok(Self {
             soft_limits: soft_limits.into_iter().collect(),
@@ -214,7 +208,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::empty_then_default(Vec::<(EventKind, f64)>::new(), vec![(EventKind::Ir, 10f64)])]
+    #[case::empty(Vec::<(EventKind, f64)>::new(), Vec::<(EventKind, f64)>::new())]
     #[case::single(vec![(Ir, 0f64)], vec![(Ir, 0f64)])]
     #[case::two(vec![(Ir, 0f64), (Dr, 10f64)], vec![(Ir, 0f64), (Dr, 10f64)])]
     #[case::duplicate(vec![(Ir, 0f64), (Ir, 10f64)], vec![(Ir, 10f64)])]
@@ -253,7 +247,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::empty_then_default(Vec::<(EventKind, f64)>::new(), Vec::<(EventKind, f64)>::new())]
+    #[case::empty(Vec::<(EventKind, f64)>::new(), Vec::<(EventKind, f64)>::new())]
     #[case::single(vec![(Ir, 0)], vec![(Ir, 0)])]
     #[case::single_convert(vec![(L1HitRate, 1)], vec![(L1HitRate, 1f64)])]
     #[case::two(vec![(Ir, 0), (Dr, 2)], vec![(Ir, 0), (Dr, 2)])]
@@ -295,11 +289,7 @@ mod tests {
         V: Into<Metric>,
     {
         let expected = CallgrindRegressionConfig {
-            soft_limits: if hard_limits.is_empty() {
-                vec![(EventKind::Ir, 10f64)]
-            } else {
-                Vec::default()
-            },
+            soft_limits: Vec::default(),
             hard_limits: expected_hard_limits
                 .into_iter()
                 .map(|(m, l)| (m, l.into()))

--- a/gungraun-runner/src/runner/dhat/regression.rs
+++ b/gungraun-runner/src/runner/dhat/regression.rs
@@ -93,34 +93,28 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::api::DhatMetrics;
+    use crate::api::{DhatMetrics, Limit};
+    use crate::fixtures::api::dhat_regression_config_f as api_dhat_regression_config_f;
+    use crate::fixtures::dhat_regression_config_f;
     use crate::metrics::model::Metrics;
     use crate::runner::tool::regression::RegressionMetrics;
 
     #[rstest]
-    #[case(
-        api::DhatRegressionConfig {
-            soft_limits: Vec::default(),
-            hard_limits: Vec::default(),
-            fail_fast: Some(true),
-        },
-        DhatRegressionConfig {
-            soft_limits: Vec::default(),
-            hard_limits: Vec::default(),
-            fail_fast: true,
-        }
+    #[case::fail_fast(
+        api_dhat_regression_config_f().fail_fast(true).fixture(),
+        dhat_regression_config_f().fail_fast(true).fixture(),
     )]
-    #[case(
-        api::DhatRegressionConfig {
-            soft_limits: vec![(DhatMetrics::from(DhatMetric::TotalBytes), 5f64)],
-            hard_limits: Vec::default(),
-            fail_fast: Some(true),
-        },
-        DhatRegressionConfig {
-            soft_limits: vec![(TotalBytes, 5f64)],
-            hard_limits: Vec::default(),
-            fail_fast: true,
-        }
+    #[case::soft_limit(
+        api_dhat_regression_config_f()
+            .soft_limits(vec![(DhatMetrics::from(TotalBytes), 5f64)])
+            .fixture(),
+        dhat_regression_config_f().soft_limits(vec![(TotalBytes, 5f64)]).fixture(),
+    )]
+    #[case::hard_limit(
+        api_dhat_regression_config_f()
+            .hard_limits(vec![(DhatMetrics::from(TotalBytes), Limit::Int(10))])
+            .fixture(),
+        dhat_regression_config_f().hard_limits(vec![(TotalBytes, Metric::Int(10))]).fixture(),
     )]
     fn test_try_from_regression_config(
         #[case] input: api::DhatRegressionConfig,

--- a/gungraun-runner/src/runner/dhat/regression.rs
+++ b/gungraun-runner/src/runner/dhat/regression.rs
@@ -54,38 +54,29 @@ impl TryFrom<api::DhatRegressionConfig> for DhatRegressionConfig {
             fail_fast,
         } = value;
 
-        let (soft_limits, hard_limits) = if soft_limits.is_empty() && hard_limits.is_empty() {
-            (
-                IndexMap::from([(DhatMetric::TotalBytes, 10f64)]),
-                IndexMap::new(),
-            )
-        } else {
-            let hard_limits = hard_limits
-                .into_iter()
-                .flat_map(|(dhat_metrics, metric)| {
-                    IndexSet::from(dhat_metrics)
-                        .into_iter()
-                        .map(move |metric_kind| {
-                            Metric::from(metric)
-                                .try_convert(metric_kind)
-                                .ok_or_else(|| {
-                                    format!(
-                                        "Invalid hard limit for \
-                                         '{metric_kind:?}/{dhat_metrics:?}': Expected a 'Int' but \
-                                         found '{metric:?}'"
-                                    )
-                                })
-                        })
-                })
-                .collect::<Result<IndexMap<DhatMetric, Metric>, String>>()?;
+        let hard_limits = hard_limits
+            .into_iter()
+            .flat_map(|(dhat_metrics, metric)| {
+                IndexSet::from(dhat_metrics)
+                    .into_iter()
+                    .map(move |metric_kind| {
+                        Metric::from(metric)
+                            .try_convert(metric_kind)
+                            .ok_or_else(|| {
+                                format!(
+                                    "Invalid hard limit for '{metric_kind:?}/{dhat_metrics:?}': \
+                                     Expected a 'Int' but found '{metric:?}'"
+                                )
+                            })
+                    })
+            })
+            .collect::<Result<IndexMap<DhatMetric, Metric>, String>>()?;
 
-            let soft_limits = soft_limits
-                .into_iter()
-                .flat_map(|(m, l)| IndexSet::from(m).into_iter().map(move |e| (e, l)))
-                .collect::<IndexMap<_, _>>();
+        let soft_limits = soft_limits
+            .into_iter()
+            .flat_map(|(m, l)| IndexSet::from(m).into_iter().map(move |e| (e, l)))
+            .collect::<IndexMap<_, _>>();
 
-            (soft_limits, hard_limits)
-        };
         Ok(Self {
             soft_limits: soft_limits.into_iter().collect(),
             hard_limits: hard_limits.into_iter().collect(),
@@ -102,8 +93,43 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::api::DhatMetrics;
     use crate::metrics::model::Metrics;
     use crate::runner::tool::regression::RegressionMetrics;
+
+    #[rstest]
+    #[case(
+        api::DhatRegressionConfig {
+            soft_limits: Vec::default(),
+            hard_limits: Vec::default(),
+            fail_fast: Some(true),
+        },
+        DhatRegressionConfig {
+            soft_limits: Vec::default(),
+            hard_limits: Vec::default(),
+            fail_fast: true,
+        }
+    )]
+    #[case(
+        api::DhatRegressionConfig {
+            soft_limits: vec![(DhatMetrics::from(DhatMetric::TotalBytes), 5f64)],
+            hard_limits: Vec::default(),
+            fail_fast: Some(true),
+        },
+        DhatRegressionConfig {
+            soft_limits: vec![(TotalBytes, 5f64)],
+            hard_limits: Vec::default(),
+            fail_fast: true,
+        }
+    )]
+    fn test_try_from_regression_config(
+        #[case] input: api::DhatRegressionConfig,
+        #[case] expected: DhatRegressionConfig,
+    ) {
+        let config = DhatRegressionConfig::try_from(input).unwrap();
+
+        assert_eq!(config, expected);
+    }
 
     fn costs_fixture(costs: [u64; 2]) -> Metrics<DhatMetric> {
         Metrics::with_metric_kinds([(TotalBytes, costs[0]), (TotalBlocks, costs[1])])

--- a/gungraun/src/common.rs
+++ b/gungraun/src/common.rs
@@ -583,14 +583,18 @@ impl Cachegrind {
     /// If set to true, then the benchmarks fail on the first encountered regression
     ///
     /// The default is `false` and the whole benchmark run fails with a regression error after all
-    /// benchmarks have been run.
+    /// benchmarks have been run. This option does not enable regression checks by itself. Configure
+    /// regression checks explicitly with [`Cachegrind::soft_limits`] or
+    /// [`Cachegrind::hard_limits`].
     ///
     /// # Examples
     ///
     /// ```
-    /// use gungraun::Cachegrind;
+    /// use gungraun::{Cachegrind, CachegrindMetric};
     ///
-    /// let config = Cachegrind::default().fail_fast(true);
+    /// let config = Cachegrind::default()
+    ///     .soft_limits([(CachegrindMetric::Ir, 5f64)])
+    ///     .fail_fast(true);
     /// ```
     pub fn fail_fast(&mut self, value: bool) -> &mut Self {
         if let Some(__internal::InternalToolRegressionConfig::Cachegrind(config)) =
@@ -905,14 +909,17 @@ impl Callgrind {
     /// If set to true, then the benchmarks fail on the first encountered regression
     ///
     /// The default is `false` and the whole benchmark run fails with a regression error after all
-    /// benchmarks have been run.
+    /// benchmarks have been run. This option does not enable regression checks by itself. Configure
+    /// regression checks explicitly with [`Callgrind::soft_limits`] or [`Callgrind::hard_limits`].
     ///
     /// # Examples
     ///
     /// ```
-    /// use gungraun::Callgrind;
+    /// use gungraun::{Callgrind, EventKind};
     ///
-    /// let config = Callgrind::default().fail_fast(true);
+    /// let config = Callgrind::default()
+    ///     .soft_limits([(EventKind::Ir, 5f64)])
+    ///     .fail_fast(true);
     /// ```
     pub fn fail_fast(&mut self, value: bool) -> &mut Self {
         if let Some(__internal::InternalToolRegressionConfig::Callgrind(config)) =
@@ -1448,14 +1455,17 @@ impl Dhat {
     /// If set to true, then the benchmarks fail on the first encountered regression
     ///
     /// The default is `false` and the whole benchmark run fails with a regression error after all
-    /// benchmarks have been run.
+    /// benchmarks have been run. This option does not enable regression checks by itself. Configure
+    /// regression checks explicitly with [`Dhat::soft_limits`] or [`Dhat::hard_limits`].
     ///
     /// # Examples
     ///
     /// ```
-    /// use gungraun::Dhat;
+    /// use gungraun::{Dhat, DhatMetric};
     ///
-    /// let config = Dhat::default().fail_fast(true);
+    /// let config = Dhat::default()
+    ///     .soft_limits([(DhatMetric::TotalBytes, 5f64)])
+    ///     .fail_fast(true);
     /// ```
     pub fn fail_fast(&mut self, value: bool) -> &mut Self {
         if let Some(__internal::InternalToolRegressionConfig::Dhat(config)) =


### PR DESCRIPTION
Only setting fail-fast to true or false shouldn't apply a default regression check. Regression checks are required to be set explicitly.

---
AI Tools were used to create this PR