### PR TITLE
chore: Update crossbeam-epoch and inferno. Fix RUSTSEC-2026-0204, RUSTSEC-2026-0194, RUSTSEC-2026-0195

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
@@ -268,9 +268,9 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "camino"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -462,18 +462,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -481,27 +481,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "cty"
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -570,12 +570,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1108,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90807d610575744524d9bdc69f3885d96f0e6c3354565b0828354a7ff2a262b8"
+checksum = "d2c05b9ae050366b3363927f59d2c07f922a746e97e2e96f70d479a3c7dbbbe5"
 dependencies = [
  "ahash",
  "crossbeam-channel",
@@ -1157,9 +1156,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -1171,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1271,9 +1270,9 @@ checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memo-map"
@@ -1554,16 +1553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro-error-attr3"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,18 +1560,6 @@ checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1608,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.215"
+version = "2.1.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff7403e06671f170c65dc7bf475ed31d6e108c7e0d2440fb4df8ba56cfded6"
+checksum = "f558d33d882cb296fb65dbe0246b98b90e761fbe00c552701d2030eb5bbce63a"
 dependencies = [
  "psl-types",
 ]
@@ -1623,9 +1600,9 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1697,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1709,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1767,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1795,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2633,18 +2610,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -578,17 +578,6 @@ impl Benchmark {
         command.args(["bench", "--package", PACKAGE, "--bench", &self.bench_name]);
         command.args(cargo_args);
 
-        // FIX: A temporary measure due to intermittent errors in the ci when comparing two
-        // consecutive runs and there is no difference expected but there is a difference of 5
-        // instructions and a single data cache read in
-        // ./string/../sysdeps/x86_64/multiarch/memchr-avx2.S. Remove this fix if the glibc version
-        // has been updated including the ubuntu specific version which had recently been patched
-        // which might caused this issue.
-        let mut envs = envs.clone();
-        if !cfg!(target_os = "macos") {
-            envs.insert("RUSTFLAGS".to_owned(), "-C target-feature=-avx2".to_owned());
-        }
-
         if !envs.is_empty() {
             let envs_string = envs
                 .iter()

--- a/benchmark-tests/src/bench.rs
+++ b/benchmark-tests/src/bench.rs
@@ -717,7 +717,7 @@ impl Benchmark {
             for tries in 0..=max_tries {
                 print_info(format!(
                     "Running {}: Group: ({}/{num_groups}), Run: ({}/{})",
-                    &self.config_name,
+                    self.config_name,
                     group_index + 1,
                     index + 1,
                     num_runs
@@ -785,7 +785,7 @@ impl Benchmark {
                     } else {
                         print_info(format!(
                             "Flaky test: Re-running {}: ({}/{max_tries})",
-                            &self.config_name,
+                            self.config_name,
                             tries + 1,
                         ));
                         self.restore(backup_dir.as_ref());

--- a/benchmark-tests/valgrind-suppressions.supp
+++ b/benchmark-tests/valgrind-suppressions.supp
@@ -20,6 +20,17 @@
    ...
 }
 {
+   drd_delete_current_info_drop_glue
+   drd:ConflictingAccess
+   ...
+   fun:delete_current_info
+   fun:*stack_overflow3imp12drop_handler*
+   fun:drop
+   fun:drop_glue<std::sys::pal::unix::stack_overflow::Handler>
+   fun:*Thread3new12thread_start*
+   ...
+}
+{
    memcheck_set_current_info
    Memcheck:Leak
    match-leak-kinds: reachable

--- a/client-request-tests/tests/test_client_requests/cachegrind.rs
+++ b/client-request-tests/tests/test_client_requests/cachegrind.rs
@@ -50,7 +50,7 @@ fn test_cachegrind_reqs_when_running_on_valgrind() {
             err.write_all(&output.stderr).unwrap();
             panic!(
                 "Assertion of exit code failed: Actual: {}, Expected: {}",
-                &output.status.code().unwrap(),
+                output.status.code().unwrap(),
                 expected_code
             )
         }

--- a/client-request-tests/tests/test_client_requests/memcheck.rs
+++ b/client-request-tests/tests/test_client_requests/memcheck.rs
@@ -100,7 +100,7 @@ total heap usage: <__FILTER__>"
             err.write_all(&output.stderr).unwrap();
             panic!(
                 "Assertion of exit code failed: Actual: {}, Expected: {}",
-                &output.status.code().unwrap(),
+                output.status.code().unwrap(),
                 expected_code
             )
         }

--- a/client-request-tests/tests/test_client_requests/print_macros.rs
+++ b/client-request-tests/tests/test_client_requests/print_macros.rs
@@ -49,7 +49,7 @@ fn test_client_request_print_macros_when_running_on_valgrind() {
             err.write_all(&output.stderr).unwrap();
             panic!(
                 "Assertion of exit code failed: Actual: {}, Expected: {}",
-                &output.status.code().unwrap(),
+                output.status.code().unwrap(),
                 expected_code
             )
         }

--- a/client-request-tests/tests/test_client_requests/valgrind.rs
+++ b/client-request-tests/tests/test_client_requests/valgrind.rs
@@ -101,7 +101,7 @@ Rerun with --leak-check=full to see details of leaked memory"
             err.write_all(&output.stderr).unwrap();
             panic!(
                 "Assertion of exit code failed: Actual: {}, Expected: {}",
-                &output.status.code().unwrap(),
+                output.status.code().unwrap(),
                 expected_code
             )
         }

--- a/deny.toml
+++ b/deny.toml
@@ -73,9 +73,6 @@ feature-depth = 1
 ignore = [
   # warning that paste (transitive from polonius) is unmaintained
   "RUSTSEC-2024-0436",
-  # transitive from inferno which needs to update quick-xml to 0.41
-  "RUSTSEC-2026-0194",
-  "RUSTSEC-2026-0195",
   # https://rustsec.org/advisories/RUSTSEC-2024-0421
   #"RUSTSEC-0000-0000",
   #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish

--- a/gungraun-runner/src/runner/cachegrind/summary_parser.rs
+++ b/gungraun-runner/src/runner/cachegrind/summary_parser.rs
@@ -52,7 +52,7 @@ impl Parser for SummaryParser {
                 inner.add_iter_str(suffix.split_ascii_whitespace())?;
                 metrics = Some(inner);
 
-                trace!("Updated counters to '{:?}'", &metrics);
+                trace!("Updated counters to '{metrics:?}'");
             }
         }
 

--- a/gungraun-runner/src/runner/callgrind/flamegraph.rs
+++ b/gungraun-runner/src/runner/callgrind/flamegraph.rs
@@ -548,7 +548,7 @@ impl OutputPath {
             let entry = entry?;
             let file_name = entry.file_name().to_string_lossy().to_string();
             if let Some(suffix) =
-                file_name.strip_prefix(format!("callgrind.{}", &self.name).as_str())
+                file_name.strip_prefix(format!("callgrind.{}", self.name).as_str())
             {
                 let path = entry.path();
 
@@ -692,7 +692,7 @@ impl OutputPath {
             let path = entry?;
             let file_name = path.file_name().to_string_lossy().to_string();
             if let Some(suffix) =
-                file_name.strip_prefix(format!("callgrind.{}.", &self.name).as_str())
+                file_name.strip_prefix(format!("callgrind.{}.", self.name).as_str())
             {
                 if suffix.ends_with(to_match) {
                     paths.push(path.path());

--- a/gungraun-runner/src/runner/callgrind/summary_parser.rs
+++ b/gungraun-runner/src/runner/callgrind/summary_parser.rs
@@ -70,7 +70,7 @@ impl CallgrindParser for SummaryParser {
                 inner.add_iter_str(suffix.split_ascii_whitespace())?;
                 metrics = Some(inner);
 
-                trace!("Updated counters to '{:?}'", &metrics);
+                trace!("Updated counters to '{metrics:?}'");
             }
 
             if let Some(suffix) = line.strip_prefix("totals:") {
@@ -80,7 +80,7 @@ impl CallgrindParser for SummaryParser {
                 inner.add_iter_str(suffix.split_ascii_whitespace())?;
                 metrics = Some(inner);
 
-                trace!("Updated counters to '{:?}'", &metrics);
+                trace!("Updated counters to '{metrics:?}'");
                 break;
             }
         }

--- a/gungraun-runner/src/runner/lib_bench.rs
+++ b/gungraun-runner/src/runner/lib_bench.rs
@@ -429,7 +429,7 @@ impl LibBench {
     /// [`Group`]: [crate::runner::common::Group]
     fn name(&self) -> String {
         if let Some(bench_id) = &self.id {
-            format!("{}.{}", &self.function_name, bench_id)
+            format!("{}.{}", self.function_name, bench_id)
         } else {
             self.function_name.clone()
         }

--- a/gungraun-runner/src/runner/tool/args.rs
+++ b/gungraun-runner/src/runner/tool/args.rs
@@ -338,8 +338,8 @@ impl ValgrindArgs {
         let mut vec: Vec<OsString> = vec![];
 
         vec.push(format!("--tool={}", self.tool.id()).into());
-        vec.push(format!("--error-exitcode={}", &self.error_exitcode).into());
-        vec.push(format!("--trace-children={}", &bool_to_yesno(self.trace_children)).into());
+        vec.push(format!("--error-exitcode={}", self.error_exitcode).into());
+        vec.push(format!("--trace-children={}", bool_to_yesno(self.trace_children)).into());
         vec.push(format!("--fair-sched={}", self.fair_sched).into());
         vec.push(format!("--vgdb={}", self.vgdb).into());
         if self.verbose {

--- a/gungraun/src/bin_bench.rs
+++ b/gungraun/src/bin_bench.rs
@@ -734,34 +734,34 @@ impl BenchmarkId {
                 if index > MAX_LENGTH_ID {
                     return Err(format!(
                         "Invalid id '{}': Maximum length of {MAX_LENGTH_ID} bytes reached",
-                        &self.0,
+                        self.0,
                     ));
                 }
                 if byte.is_ascii() {
                     if !(byte.is_ascii_alphanumeric() || byte == b'_') {
                         return Err(format!(
                             "Invalid id '{}' at position {index}: Invalid character '{}'",
-                            &self.0,
+                            self.0,
                             char::from(byte)
                         ));
                     }
                 } else {
                     return Err(format!(
                         "Invalid id '{}' at position {index}: Encountered non-ascii character",
-                        &self.0
+                        self.0
                     ));
                 }
             }
         } else if first.is_ascii() {
             return Err(format!(
                 "Invalid id '{}': As first character is '{}' not allowed",
-                &self.0,
+                self.0,
                 char::from(first)
             ));
         } else {
             return Err(format!(
                 "Invalid id '{}': Encountered non-ascii character as first character",
-                &self.0
+                self.0
             ));
         }
         Ok(())

--- a/valgrind-requests/src/valgrind.rs
+++ b/valgrind-requests/src/valgrind.rs
@@ -174,7 +174,6 @@ pub fn get_toolname(buffer: *mut u8, len: usize) -> usize {
 /// with them that subsequently calls `printf()`, there's a high chance Valgrind will crash.
 /// Generally, your prospects of these working are made higher if the called function does not refer
 /// to any global variables, and does not refer to other functions (print! et al.).
-#[expect(clippy::fn_to_numeric_cast_any)]
 #[inline(always)]
 pub fn non_simd_call0(func: fn(ThreadId) -> usize) -> usize {
     do_client_request!(
@@ -203,7 +202,6 @@ pub fn non_simd_call0(func: fn(ThreadId) -> usize) -> usize {
 /// );
 /// assert_eq!(res, 44);
 /// ```
-#[expect(clippy::fn_to_numeric_cast_any)]
 #[inline(always)]
 pub fn non_simd_call1(func: fn(ThreadId, usize) -> usize, arg1: usize) -> usize {
     do_client_request!(
@@ -221,7 +219,6 @@ pub fn non_simd_call1(func: fn(ThreadId, usize) -> usize, arg1: usize) -> usize 
 /// Allow control to move from the simulated CPU to the real CPU, calling an arbitrary function.
 ///
 /// See also [`non_simd_call0`] and [`non_simd_call1`]
-#[expect(clippy::fn_to_numeric_cast_any)]
 #[inline(always)]
 pub fn non_simd_call2(
     func: fn(ThreadId, usize, usize) -> usize,
@@ -243,7 +240,6 @@ pub fn non_simd_call2(
 /// Allow control to move from the simulated CPU to the real CPU, calling an arbitrary function.
 ///
 /// See also [`non_simd_call0`] and [`non_simd_call1`]
-#[expect(clippy::fn_to_numeric_cast_any)]
 #[inline(always)]
 pub fn non_simd_call3(
     func: fn(ThreadId, usize, usize, usize) -> usize,


### PR DESCRIPTION
This PR updates all dependencies. Updating crossbeam-epoch fixes RUSTSEC-2026-0204. Updating inferno fixes RUSTSEC-2026-0194, RUSTSEC-2026-0195.

Also, fix all clippy warnings from new rust stable release.