### PR TITLE
chore(deps): Bump syn to v3 and proc-macro-error3 to 3.0.3

### DIFF
--- a/.dicts/custom.txt
+++ b/.dicts/custom.txt
@@ -102,6 +102,7 @@ gmax
 gnuabi
 gnueabi
 gnueabihf
+graphify
 grcov
 gungnir
 gungraun

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ callgrind.out*
 callgrind.log*
 cachegrind.out*
 cachegrind.log*
+graphify-out/
+entities.json
+mempalace.yaml
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,2 @@
+docs/book/
+.omo/

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@ docs/theme
 *.supp
 *.stderr
 *.stdout
+graphify-out/
+.omo/
+.serena

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1564,14 +1564,14 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+checksum = "dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1882,7 +1882,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2183,7 +2183,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ polonius-the-crab = { version = "0.5" }
 predicates = { version = "3" }
 pretty_assertions = "1.1"
 proc-macro-error3 = "3.0.0"
-proc-macro2 = "1.0.88"
+proc-macro2 = "1.0.91"
 quote = "1.0.35"
 regex = { version = "1.12" }
 rstest = { version = ">=0.17, <0.27", default-features = false }
@@ -74,7 +74,7 @@ shlex = { version = "2.0" }
 signal-hook = { version = "0.4" }
 simplematch = "0.3"
 strum = { version = "0.28" }
-syn = { version = "2.0.87", features = ["full", "extra-traits"] }
+syn = { version = "3", features = ["full", "extra-traits"] }
 tempfile = { version = "3.10.0" }
 thiserror = { version = "2.0.3" }
 trybuild = "1.0.18"

--- a/Justfile
+++ b/Justfile
@@ -121,8 +121,8 @@ generate-lockfile:
 
 # Generate and update Cargo.lock with cargo resolver v3 fallback (Uses: 'cargo +stable')
 [group('dependencies')]
-update-dependencies:
-    CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo +stable update
+update-dependencies *args:
+    CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo +stable update {{ args }}
 
 # Install git hooks (Uses: 'coreutils')
 [group('init workspace')]

--- a/gungraun-macros/src/bin_bench.rs
+++ b/gungraun-macros/src/bin_bench.rs
@@ -528,6 +528,7 @@ impl BinaryBenchmark {
             vis: visibility,
             sig: item_fn.sig.clone(),
             block: item_fn.block.clone(),
+            modifiers: item_fn.modifiers.clone(),
         };
 
         let config = self.config.render_as_code();
@@ -567,6 +568,7 @@ impl BinaryBenchmark {
             vis: syn::Visibility::Inherited,
             sig: item_fn.sig.clone(),
             block: item_fn.block.clone(),
+            modifiers: item_fn.modifiers.clone(),
         };
 
         let mod_name = &item_fn.sig.ident;

--- a/gungraun-macros/src/lib_bench.rs
+++ b/gungraun-macros/src/lib_bench.rs
@@ -897,6 +897,7 @@ fn create_item_fn(item_fn: &ItemFn) -> ItemFn {
         vis,
         sig: item_fn.sig.clone(),
         block,
+        modifiers: item_fn.modifiers.clone(),
     }
 }
 
@@ -908,6 +909,7 @@ fn create_item_fn(item_fn: &ItemFn) -> ItemFn {
         vis,
         sig: item_fn.sig.clone(),
         block: item_fn.block.clone(),
+        modifiers: item_fn.modifiers.clone(),
     }
 }
 


### PR DESCRIPTION
This PR bumps syn to v3 and fixes the missing ItemFn::mofifiers errors.

Closes #703
Closes #706 